### PR TITLE
fix: correct DigitalOcean deploy action path and preview flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,12 +47,12 @@ jobs:
           VITE_GITHUB_CONNECTED: 'true'
 
       - name: Deploy to DigitalOcean
-        uses: digitalocean/app_action@v2
+    uses: digitalocean/app_action/deploy@v2
         with:
           app_name: fluxstudio
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
           app_spec_location: .do/app.yaml
-          pr_preview: ${{ github.event_name == 'pull_request' }}
+    deploy_pr_preview: ${{ github.event_name == 'pull_request' }}
 
       - name: Comment PR with preview URL
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Update .github/workflows/deploy.yml to use digitalocean/app_action/deploy@v2 and rename pr_preview to deploy_pr_preview. This fixes the unexpected input errors and enables deploy previews.