### PR TITLE
feat(metmap): Add customizable metronome with visual feedback

### DIFF
--- a/metmap/src/app/song/[id]/practice/page.tsx
+++ b/metmap/src/app/song/[id]/practice/page.tsx
@@ -13,8 +13,11 @@ import {
   Check,
   Clock,
   Zap,
+  Music,
+  ChevronDown,
 } from 'lucide-react';
 import { useMetMapStore } from '@/stores/useMetMapStore';
+import { MetronomeControls } from '@/components/MetronomeControls';
 import {
   ConfidenceLevel,
   SECTION_COLORS,
@@ -48,6 +51,7 @@ export default function PracticeModePage() {
   const [isPaused, setIsPaused] = useState(true);
   const [practiceTime, setPracticeTime] = useState(0);
   const [showEndSessionModal, setShowEndSessionModal] = useState(false);
+  const [showMetronome, setShowMetronome] = useState(false);
 
   // Simulated playback state (in real app, this would connect to audio player)
   const [currentTime, setCurrentTime] = useState(0);
@@ -298,7 +302,7 @@ export default function PracticeModePage() {
           </button>
         </div>
 
-        {/* Loop toggle and mark complete */}
+        {/* Loop toggle, metronome toggle, and mark complete */}
         <div className="flex items-center justify-between">
           <button
             onClick={() => setIsLooping(!isLooping)}
@@ -314,6 +318,25 @@ export default function PracticeModePage() {
           </button>
 
           <button
+            onClick={() => setShowMetronome(!showMetronome)}
+            className={clsx(
+              'flex items-center gap-2 px-4 py-2 rounded-lg tap-target',
+              showMetronome
+                ? 'bg-blue-500/20 text-blue-400'
+                : 'text-gray-400 hover:bg-gray-800'
+            )}
+          >
+            <Music className="w-5 h-5" />
+            <span className="text-sm">Metronome</span>
+            <ChevronDown
+              className={clsx(
+                'w-4 h-4 transition-transform',
+                showMetronome && 'rotate-180'
+              )}
+            />
+          </button>
+
+          <button
             onClick={handleSectionComplete}
             className="flex items-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded-lg tap-target"
           >
@@ -321,6 +344,13 @@ export default function PracticeModePage() {
             <span className="text-sm">Mark Done</span>
           </button>
         </div>
+
+        {/* Metronome Panel */}
+        {showMetronome && (
+          <div className="mt-4">
+            <MetronomeControls />
+          </div>
+        )}
       </div>
 
       {/* Section Quick Nav */}

--- a/metmap/src/components/MetronomeControls.tsx
+++ b/metmap/src/components/MetronomeControls.tsx
@@ -1,0 +1,339 @@
+'use client';
+
+import { useState } from 'react';
+import { useMetronome, SoundPreset } from '@/hooks/useMetronome';
+import { TIME_SIGNATURES, getAccentPatterns } from '@/lib/accentPatterns';
+import { SOUND_PRESETS } from '@/lib/metronome';
+
+interface MetronomeControlsProps {
+  className?: string;
+  onTempoChange?: (bpm: number) => void;
+}
+
+export function MetronomeControls({
+  className = '',
+  onTempoChange,
+}: MetronomeControlsProps) {
+  const {
+    isPlaying,
+    tempo,
+    timeSignature,
+    beatsPerMeasure,
+    currentBeat,
+    soundPreset,
+    subdivisions,
+    accentPattern,
+    beatPulse,
+    isDownbeat,
+    toggle,
+    setTempo,
+    setTimeSignature,
+    setSoundPreset,
+    setSubdivisions,
+    setAccentPattern,
+    tap,
+  } = useMetronome();
+
+  const [showSettings, setShowSettings] = useState(false);
+
+  const handleTempoChange = (bpm: number) => {
+    setTempo(bpm);
+    onTempoChange?.(bpm);
+  };
+
+  const handleTap = () => {
+    const bpm = tap();
+    if (bpm !== null) {
+      onTempoChange?.(bpm);
+    }
+  };
+
+  const availablePatterns = getAccentPatterns(timeSignature);
+
+  // Find current pattern name
+  const currentPatternName = availablePatterns.find(
+    p => JSON.stringify(p.pattern) === JSON.stringify(accentPattern)
+  )?.name || 'Custom';
+
+  return (
+    <div className={`bg-gray-900 rounded-xl p-4 ${className}`}>
+      {/* Visual Beat Display */}
+      <div className="flex items-center justify-center mb-4">
+        {/* Beat dots */}
+        <div className="flex gap-2">
+          {Array.from({ length: beatsPerMeasure }).map((_, i) => (
+            <div
+              key={i}
+              className={`
+                w-4 h-4 rounded-full transition-all duration-100
+                ${currentBeat === i && isPlaying
+                  ? i === 0
+                    ? 'bg-red-500 scale-125 shadow-lg shadow-red-500/50'
+                    : 'bg-blue-400 scale-110 shadow-lg shadow-blue-400/50'
+                  : accentPattern[i] >= 0.8
+                    ? 'bg-gray-500'
+                    : 'bg-gray-700'
+                }
+              `}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Main Pulse Indicator */}
+      <div className="flex justify-center mb-4">
+        <div
+          className={`
+            w-24 h-24 rounded-full flex items-center justify-center
+            transition-all duration-75 cursor-pointer
+            ${isPlaying
+              ? beatPulse
+                ? isDownbeat
+                  ? 'bg-red-500 scale-110 shadow-xl shadow-red-500/50'
+                  : 'bg-blue-500 scale-105 shadow-lg shadow-blue-500/40'
+                : 'bg-gray-700'
+              : 'bg-gray-800 hover:bg-gray-700'
+            }
+          `}
+          onClick={toggle}
+        >
+          {isPlaying ? (
+            <svg className="w-10 h-10 text-white" fill="currentColor" viewBox="0 0 24 24">
+              <rect x="6" y="5" width="4" height="14" rx="1" />
+              <rect x="14" y="5" width="4" height="14" rx="1" />
+            </svg>
+          ) : (
+            <svg className="w-10 h-10 text-white ml-1" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          )}
+        </div>
+      </div>
+
+      {/* Tempo Display & Controls */}
+      <div className="text-center mb-4">
+        <div className="text-4xl font-mono font-bold text-white mb-1">
+          {tempo}
+          <span className="text-lg text-gray-400 ml-1">BPM</span>
+        </div>
+        <div className="text-sm text-gray-400">
+          {timeSignature}
+          {subdivisions > 1 && ` · ${['', '', '8ths', 'triplets', '16ths'][subdivisions]}`}
+        </div>
+      </div>
+
+      {/* Tempo Slider */}
+      <div className="mb-4">
+        <input
+          type="range"
+          min="20"
+          max="300"
+          value={tempo}
+          onChange={(e) => handleTempoChange(Number(e.target.value))}
+          className="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer
+                     [&::-webkit-slider-thumb]:appearance-none
+                     [&::-webkit-slider-thumb]:w-5 [&::-webkit-slider-thumb]:h-5
+                     [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-blue-500
+                     [&::-webkit-slider-thumb]:cursor-pointer
+                     [&::-webkit-slider-thumb]:hover:bg-blue-400"
+        />
+        <div className="flex justify-between text-xs text-gray-500 mt-1">
+          <span>20</span>
+          <span>160</span>
+          <span>300</span>
+        </div>
+      </div>
+
+      {/* Quick Controls */}
+      <div className="flex gap-2 mb-4">
+        {/* Tempo adjust buttons */}
+        <button
+          onClick={() => handleTempoChange(tempo - 5)}
+          className="flex-1 py-2 px-3 bg-gray-800 hover:bg-gray-700 rounded-lg text-white
+                     active:scale-95 transition-transform min-h-[44px]"
+        >
+          -5
+        </button>
+        <button
+          onClick={() => handleTempoChange(tempo - 1)}
+          className="flex-1 py-2 px-3 bg-gray-800 hover:bg-gray-700 rounded-lg text-white
+                     active:scale-95 transition-transform min-h-[44px]"
+        >
+          -1
+        </button>
+        <button
+          onClick={handleTap}
+          className="flex-1 py-2 px-3 bg-blue-600 hover:bg-blue-500 rounded-lg text-white
+                     font-medium active:scale-95 transition-transform min-h-[44px]"
+        >
+          TAP
+        </button>
+        <button
+          onClick={() => handleTempoChange(tempo + 1)}
+          className="flex-1 py-2 px-3 bg-gray-800 hover:bg-gray-700 rounded-lg text-white
+                     active:scale-95 transition-transform min-h-[44px]"
+        >
+          +1
+        </button>
+        <button
+          onClick={() => handleTempoChange(tempo + 5)}
+          className="flex-1 py-2 px-3 bg-gray-800 hover:bg-gray-700 rounded-lg text-white
+                     active:scale-95 transition-transform min-h-[44px]"
+        >
+          +5
+        </button>
+      </div>
+
+      {/* Settings Toggle */}
+      <button
+        onClick={() => setShowSettings(!showSettings)}
+        className="w-full py-2 px-3 bg-gray-800 hover:bg-gray-700 rounded-lg text-gray-300
+                   flex items-center justify-center gap-2 min-h-[44px]"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+        Settings
+        <svg
+          className={`w-4 h-4 transition-transform ${showSettings ? 'rotate-180' : ''}`}
+          fill="none" stroke="currentColor" viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {/* Expanded Settings */}
+      {showSettings && (
+        <div className="mt-4 space-y-4 border-t border-gray-700 pt-4">
+          {/* Time Signature */}
+          <div>
+            <label className="block text-sm text-gray-400 mb-2">Time Signature</label>
+            <div className="grid grid-cols-5 gap-2">
+              {TIME_SIGNATURES.slice(0, 10).map((ts) => (
+                <button
+                  key={ts.display}
+                  onClick={() => setTimeSignature(ts.display)}
+                  className={`
+                    py-2 px-2 rounded-lg text-sm font-mono min-h-[44px]
+                    ${timeSignature === ts.display
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+                    }
+                  `}
+                >
+                  {ts.display}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Accent Pattern */}
+          <div>
+            <label className="block text-sm text-gray-400 mb-2">
+              Accent Pattern: <span className="text-white">{currentPatternName}</span>
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {availablePatterns.map((pattern) => (
+                <button
+                  key={pattern.name}
+                  onClick={() => setAccentPattern(pattern.pattern)}
+                  title={pattern.description}
+                  className={`
+                    py-2 px-3 rounded-lg text-sm min-h-[44px]
+                    ${JSON.stringify(accentPattern) === JSON.stringify(pattern.pattern)
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+                    }
+                  `}
+                >
+                  {pattern.name}
+                </button>
+              ))}
+            </div>
+            {/* Custom Pattern Editor */}
+            <div className="mt-3">
+              <div className="text-xs text-gray-500 mb-2">Tap beats to toggle accent:</div>
+              <div className="flex gap-1">
+                {accentPattern.map((level, i) => (
+                  <button
+                    key={i}
+                    onClick={() => {
+                      const newPattern = [...accentPattern];
+                      newPattern[i] = level >= 0.8 ? 0.5 : 1;
+                      setAccentPattern(newPattern);
+                    }}
+                    className={`
+                      flex-1 py-3 rounded text-xs font-mono min-h-[44px]
+                      ${level >= 0.8
+                        ? 'bg-red-600 text-white'
+                        : level >= 0.6
+                          ? 'bg-yellow-600 text-white'
+                          : 'bg-gray-700 text-gray-400'
+                      }
+                    `}
+                  >
+                    {i + 1}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Sound Preset */}
+          <div>
+            <label className="block text-sm text-gray-400 mb-2">Click Sound</label>
+            <div className="grid grid-cols-3 gap-2">
+              {(Object.keys(SOUND_PRESETS) as SoundPreset[]).map((preset) => (
+                <button
+                  key={preset}
+                  onClick={() => setSoundPreset(preset)}
+                  className={`
+                    py-2 px-3 rounded-lg text-sm capitalize min-h-[44px]
+                    ${soundPreset === preset
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+                    }
+                  `}
+                >
+                  {preset}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Subdivisions */}
+          <div>
+            <label className="block text-sm text-gray-400 mb-2">Subdivisions</label>
+            <div className="grid grid-cols-4 gap-2">
+              {[
+                { value: 1, label: 'Quarter' },
+                { value: 2, label: '8ths' },
+                { value: 3, label: 'Triplets' },
+                { value: 4, label: '16ths' },
+              ].map(({ value, label }) => (
+                <button
+                  key={value}
+                  onClick={() => setSubdivisions(value)}
+                  className={`
+                    py-2 px-2 rounded-lg text-sm min-h-[44px]
+                    ${subdivisions === value
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+                    }
+                  `}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MetronomeControls;

--- a/metmap/src/hooks/useMetronome.ts
+++ b/metmap/src/hooks/useMetronome.ts
@@ -1,0 +1,280 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  getMetronome,
+  MetronomeConfig,
+  MetronomeState,
+  SOUND_PRESETS,
+} from '@/lib/metronome';
+import { getDefaultAccentPattern } from '@/lib/accentPatterns';
+
+export type SoundPreset = keyof typeof SOUND_PRESETS;
+
+export interface UseMetronomeOptions {
+  initialTempo?: number;
+  initialTimeSignature?: string;
+  soundPreset?: SoundPreset;
+  autoSave?: boolean;
+}
+
+export interface UseMetronomeReturn {
+  // State
+  isPlaying: boolean;
+  tempo: number;
+  timeSignature: string;
+  beatsPerMeasure: number;
+  beatUnit: number;
+  currentBeat: number;
+  currentSubdivision: number;
+  soundPreset: SoundPreset;
+  subdivisions: number;
+  accentPattern: number[];
+
+  // Visual sync
+  beatPulse: boolean;
+  isDownbeat: boolean;
+
+  // Actions
+  start: () => boolean;
+  stop: () => void;
+  toggle: () => boolean;
+  setTempo: (bpm: number) => void;
+  setTimeSignature: (signature: string) => void;
+  setSoundPreset: (preset: SoundPreset) => void;
+  setSubdivisions: (subdivisions: number) => void;
+  setAccentPattern: (pattern: number[]) => void;
+  tap: () => number | null;
+
+  // Config
+  config: MetronomeConfig;
+}
+
+const STORAGE_KEY = 'metmap-metronome-prefs';
+
+interface StoredPrefs {
+  tempo: number;
+  timeSignature: string;
+  soundPreset: SoundPreset;
+  subdivisions: number;
+}
+
+function loadPrefs(): Partial<StoredPrefs> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}
+
+function savePrefs(prefs: StoredPrefs): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export function useMetronome(options: UseMetronomeOptions = {}): UseMetronomeReturn {
+  const {
+    initialTempo = 120,
+    initialTimeSignature = '4/4',
+    soundPreset: initialSoundPreset = 'classic',
+    autoSave = true,
+  } = options;
+
+  // Load saved preferences
+  const savedPrefs = useRef(loadPrefs());
+
+  // Parse time signature
+  const parseTimeSignature = (sig: string): { beats: number; unit: number } => {
+    const [beats, unit] = sig.split('/').map(Number);
+    return { beats: beats || 4, unit: unit || 4 };
+  };
+
+  const initSig = parseTimeSignature(savedPrefs.current.timeSignature || initialTimeSignature);
+
+  // State
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [tempo, setTempoState] = useState(savedPrefs.current.tempo || initialTempo);
+  const [timeSignature, setTimeSignatureState] = useState(
+    savedPrefs.current.timeSignature || initialTimeSignature
+  );
+  const [beatsPerMeasure, setBeatsPerMeasure] = useState(initSig.beats);
+  const [beatUnit, setBeatUnit] = useState(initSig.unit);
+  const [currentBeat, setCurrentBeat] = useState(0);
+  const [currentSubdivision, setCurrentSubdivision] = useState(0);
+  const [soundPreset, setSoundPresetState] = useState<SoundPreset>(
+    savedPrefs.current.soundPreset || initialSoundPreset
+  );
+  const [subdivisions, setSubdivisionsState] = useState(savedPrefs.current.subdivisions || 1);
+  const [accentPattern, setAccentPatternState] = useState<number[]>(
+    getDefaultAccentPattern(savedPrefs.current.timeSignature || initialTimeSignature)
+  );
+
+  // Visual sync state
+  const [beatPulse, setBeatPulse] = useState(false);
+  const [isDownbeat, setIsDownbeat] = useState(false);
+  const pulseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Get metronome instance
+  const metronome = useRef(getMetronome());
+
+  // Initialize metronome config
+  useEffect(() => {
+    const m = metronome.current;
+    const sounds = SOUND_PRESETS[soundPreset];
+
+    m.setConfig({
+      tempo,
+      beatsPerMeasure,
+      beatUnit,
+      accentPattern,
+      subdivisions,
+      clickSound: sounds.click,
+      accentSound: sounds.accent,
+    });
+
+    // Set up beat callback for visual sync
+    m.onBeat((state: MetronomeState) => {
+      setIsPlaying(state.isPlaying);
+      setCurrentBeat(state.currentBeat);
+      setCurrentSubdivision(state.currentSubdivision);
+
+      if (state.isPlaying && state.visualBeatTime !== null) {
+        // Trigger visual pulse
+        setIsDownbeat(state.currentBeat === 0 && state.currentSubdivision === 0);
+        setBeatPulse(true);
+
+        // Clear previous timeout
+        if (pulseTimeoutRef.current) {
+          clearTimeout(pulseTimeoutRef.current);
+        }
+
+        // Reset pulse after short duration
+        pulseTimeoutRef.current = setTimeout(() => {
+          setBeatPulse(false);
+        }, 100);
+      }
+    });
+
+    return () => {
+      if (pulseTimeoutRef.current) {
+        clearTimeout(pulseTimeoutRef.current);
+      }
+    };
+  }, [tempo, beatsPerMeasure, beatUnit, accentPattern, subdivisions, soundPreset]);
+
+  // Save preferences when they change
+  useEffect(() => {
+    if (autoSave) {
+      savePrefs({
+        tempo,
+        timeSignature,
+        soundPreset,
+        subdivisions,
+      });
+    }
+  }, [tempo, timeSignature, soundPreset, subdivisions, autoSave]);
+
+  // Actions
+  const start = useCallback(() => {
+    return metronome.current.start();
+  }, []);
+
+  const stop = useCallback(() => {
+    metronome.current.stop();
+    setBeatPulse(false);
+    setIsDownbeat(false);
+  }, []);
+
+  const toggle = useCallback(() => {
+    const playing = metronome.current.toggle();
+    if (!playing) {
+      setBeatPulse(false);
+      setIsDownbeat(false);
+    }
+    return playing;
+  }, []);
+
+  const setTempo = useCallback((bpm: number) => {
+    const clamped = Math.min(400, Math.max(20, bpm));
+    setTempoState(clamped);
+    metronome.current.setTempo(clamped);
+  }, []);
+
+  const setTimeSignature = useCallback((signature: string) => {
+    const { beats, unit } = parseTimeSignature(signature);
+    const pattern = getDefaultAccentPattern(signature);
+
+    setTimeSignatureState(signature);
+    setBeatsPerMeasure(beats);
+    setBeatUnit(unit);
+    setAccentPatternState(pattern);
+
+    metronome.current.setConfig({
+      beatsPerMeasure: beats,
+      beatUnit: unit,
+      accentPattern: pattern,
+    });
+  }, []);
+
+  const setSoundPreset = useCallback((preset: SoundPreset) => {
+    setSoundPresetState(preset);
+    metronome.current.setSound(preset);
+  }, []);
+
+  const setSubdivisions = useCallback((subs: number) => {
+    const clamped = Math.min(4, Math.max(1, subs));
+    setSubdivisionsState(clamped);
+    metronome.current.setSubdivisions(clamped);
+  }, []);
+
+  const setAccentPattern = useCallback((pattern: number[]) => {
+    setAccentPatternState(pattern);
+    metronome.current.setAccentPattern(pattern);
+  }, []);
+
+  const tap = useCallback(() => {
+    const bpm = metronome.current.tap();
+    if (bpm !== null) {
+      setTempoState(bpm);
+    }
+    return bpm;
+  }, []);
+
+  return {
+    // State
+    isPlaying,
+    tempo,
+    timeSignature,
+    beatsPerMeasure,
+    beatUnit,
+    currentBeat,
+    currentSubdivision,
+    soundPreset,
+    subdivisions,
+    accentPattern,
+
+    // Visual sync
+    beatPulse,
+    isDownbeat,
+
+    // Actions
+    start,
+    stop,
+    toggle,
+    setTempo,
+    setTimeSignature,
+    setSoundPreset,
+    setSubdivisions,
+    setAccentPattern,
+    tap,
+
+    // Config
+    config: metronome.current.getConfig(),
+  };
+}

--- a/metmap/src/lib/accentPatterns.ts
+++ b/metmap/src/lib/accentPatterns.ts
@@ -1,0 +1,177 @@
+/**
+ * Accent Patterns - Predefined accent patterns for various time signatures
+ *
+ * Values represent volume multipliers:
+ * - 1.0 = Full accent (downbeat)
+ * - 0.7 = Medium accent
+ * - 0.5 = Normal beat
+ * - 0.3 = Ghost note / light beat
+ * - 0.0 = Silent (for complex patterns)
+ */
+
+export interface AccentPatternDefinition {
+  name: string;
+  pattern: number[];
+  description?: string;
+}
+
+export interface TimeSignaturePatterns {
+  default: number[];
+  patterns: AccentPatternDefinition[];
+}
+
+export const ACCENT_PATTERNS: Record<string, TimeSignaturePatterns> = {
+  // 4/4 Time
+  '4/4': {
+    default: [1, 0.5, 0.5, 0.5],
+    patterns: [
+      { name: 'Standard', pattern: [1, 0.5, 0.5, 0.5], description: 'Accent on 1' },
+      { name: 'Backbeat', pattern: [0.5, 1, 0.5, 1], description: 'Accent on 2 & 4 (rock/pop)' },
+      { name: 'Four on Floor', pattern: [1, 1, 1, 1], description: 'All beats equal (dance)' },
+      { name: '1 and 3', pattern: [1, 0.5, 0.7, 0.5], description: 'Accent on 1 and 3' },
+      { name: 'Soft', pattern: [0.7, 0.3, 0.5, 0.3], description: 'Light accents' },
+    ],
+  },
+
+  // 3/4 Time (Waltz)
+  '3/4': {
+    default: [1, 0.5, 0.5],
+    patterns: [
+      { name: 'Standard', pattern: [1, 0.5, 0.5], description: 'Accent on 1' },
+      { name: 'Waltz', pattern: [1, 0.3, 0.5], description: 'Strong 1, light 2' },
+      { name: 'Mazurka', pattern: [0.7, 1, 0.5], description: 'Accent on 2 (Polish dance)' },
+      { name: 'Even', pattern: [0.7, 0.7, 0.7], description: 'All beats equal' },
+    ],
+  },
+
+  // 2/4 Time (March)
+  '2/4': {
+    default: [1, 0.5],
+    patterns: [
+      { name: 'Standard', pattern: [1, 0.5], description: 'Accent on 1' },
+      { name: 'March', pattern: [1, 0.7], description: 'Strong downbeat' },
+      { name: 'Polka', pattern: [1, 0.3], description: 'Very light 2' },
+    ],
+  },
+
+  // 6/8 Time (Compound duple)
+  '6/8': {
+    default: [1, 0.3, 0.5, 0.7, 0.3, 0.5],
+    patterns: [
+      { name: 'Standard', pattern: [1, 0.3, 0.5, 0.7, 0.3, 0.5], description: 'Accent on 1 and 4' },
+      { name: 'Irish Jig', pattern: [1, 0.3, 0.3, 0.7, 0.3, 0.3], description: 'Strong 1 and 4' },
+      { name: 'Blues Shuffle', pattern: [1, 0, 0.5, 0.7, 0, 0.5], description: 'Shuffle feel' },
+      { name: 'Even', pattern: [0.7, 0.5, 0.5, 0.7, 0.5, 0.5], description: 'Light swing' },
+    ],
+  },
+
+  // 9/8 Time (Compound triple)
+  '9/8': {
+    default: [1, 0.3, 0.5, 0.7, 0.3, 0.5, 0.7, 0.3, 0.5],
+    patterns: [
+      { name: 'Standard', pattern: [1, 0.3, 0.5, 0.7, 0.3, 0.5, 0.7, 0.3, 0.5], description: '3 groups of 3' },
+      { name: 'Slip Jig', pattern: [1, 0.3, 0.3, 0.7, 0.3, 0.3, 0.7, 0.3, 0.3], description: 'Irish slip jig' },
+    ],
+  },
+
+  // 12/8 Time (Compound quadruple)
+  '12/8': {
+    default: [1, 0.3, 0.5, 0.7, 0.3, 0.5, 0.7, 0.3, 0.5, 0.7, 0.3, 0.5],
+    patterns: [
+      { name: 'Standard', pattern: [1, 0.3, 0.5, 0.7, 0.3, 0.5, 0.7, 0.3, 0.5, 0.7, 0.3, 0.5], description: '4 groups of 3' },
+      { name: 'Blues', pattern: [1, 0, 0.5, 0.7, 0, 0.5, 0.7, 0, 0.5, 0.7, 0, 0.5], description: 'Slow blues' },
+    ],
+  },
+
+  // 5/4 Time (Irregular)
+  '5/4': {
+    default: [1, 0.5, 0.5, 0.7, 0.5],
+    patterns: [
+      { name: '3+2', pattern: [1, 0.5, 0.5, 0.7, 0.5], description: 'Groups of 3 then 2' },
+      { name: '2+3', pattern: [1, 0.5, 0.7, 0.5, 0.5], description: 'Groups of 2 then 3' },
+      { name: 'Take Five', pattern: [1, 0.3, 0.5, 0.7, 0.3], description: 'Jazz style (Dave Brubeck)' },
+    ],
+  },
+
+  // 7/8 Time (Irregular)
+  '7/8': {
+    default: [1, 0.5, 0.7, 0.5, 0.7, 0.5, 0.5],
+    patterns: [
+      { name: '2+2+3', pattern: [1, 0.5, 0.7, 0.5, 0.7, 0.5, 0.5], description: 'Common grouping' },
+      { name: '3+2+2', pattern: [1, 0.5, 0.5, 0.7, 0.5, 0.7, 0.5], description: 'Bulgarian rhythm' },
+      { name: '3+4', pattern: [1, 0.5, 0.5, 0.7, 0.5, 0.5, 0.5], description: 'Simple split' },
+    ],
+  },
+
+  // 7/4 Time
+  '7/4': {
+    default: [1, 0.5, 0.5, 0.7, 0.5, 0.5, 0.5],
+    patterns: [
+      { name: '4+3', pattern: [1, 0.5, 0.5, 0.5, 0.7, 0.5, 0.5], description: '4 then 3' },
+      { name: '3+4', pattern: [1, 0.5, 0.5, 0.7, 0.5, 0.5, 0.5], description: '3 then 4' },
+      { name: 'Money', pattern: [1, 0.5, 0.7, 0.5, 0.7, 0.5, 0.5], description: 'Pink Floyd style' },
+    ],
+  },
+
+  // 11/8 Time (Irregular)
+  '11/8': {
+    default: [1, 0.5, 0.5, 0.7, 0.5, 0.5, 0.7, 0.5, 0.7, 0.5, 0.5],
+    patterns: [
+      { name: '3+3+3+2', pattern: [1, 0.5, 0.5, 0.7, 0.5, 0.5, 0.7, 0.5, 0.5, 0.7, 0.5], description: 'Common grouping' },
+      { name: '2+2+3+2+2', pattern: [1, 0.5, 0.7, 0.5, 0.7, 0.5, 0.5, 0.7, 0.5, 0.7, 0.5], description: 'Balkan style' },
+    ],
+  },
+};
+
+// Common time signatures for UI dropdown
+export const TIME_SIGNATURES = [
+  { display: '4/4', beatsPerMeasure: 4, beatUnit: 4 },
+  { display: '3/4', beatsPerMeasure: 3, beatUnit: 4 },
+  { display: '2/4', beatsPerMeasure: 2, beatUnit: 4 },
+  { display: '6/8', beatsPerMeasure: 6, beatUnit: 8 },
+  { display: '9/8', beatsPerMeasure: 9, beatUnit: 8 },
+  { display: '12/8', beatsPerMeasure: 12, beatUnit: 8 },
+  { display: '5/4', beatsPerMeasure: 5, beatUnit: 4 },
+  { display: '7/8', beatsPerMeasure: 7, beatUnit: 8 },
+  { display: '7/4', beatsPerMeasure: 7, beatUnit: 4 },
+  { display: '11/8', beatsPerMeasure: 11, beatUnit: 8 },
+];
+
+/**
+ * Get the default accent pattern for a time signature
+ */
+export function getDefaultAccentPattern(timeSignature: string): number[] {
+  const patterns = ACCENT_PATTERNS[timeSignature];
+  if (patterns) {
+    return [...patterns.default];
+  }
+
+  // Fallback: create a basic pattern with accent on beat 1
+  const [beatsStr] = timeSignature.split('/');
+  const beats = parseInt(beatsStr) || 4;
+  return Array(beats).fill(0.5).map((v, i) => i === 0 ? 1 : v);
+}
+
+/**
+ * Get all available patterns for a time signature
+ */
+export function getAccentPatterns(timeSignature: string): AccentPatternDefinition[] {
+  const patterns = ACCENT_PATTERNS[timeSignature];
+  if (patterns) {
+    return patterns.patterns;
+  }
+  return [{ name: 'Standard', pattern: getDefaultAccentPattern(timeSignature) }];
+}
+
+/**
+ * Create a custom accent pattern by setting specific beats
+ */
+export function createCustomPattern(beats: number, accents: number[]): number[] {
+  const pattern = Array(beats).fill(0.5);
+  accents.forEach(beat => {
+    if (beat >= 0 && beat < beats) {
+      pattern[beat] = 1;
+    }
+  });
+  return pattern;
+}

--- a/metmap/src/lib/metronome.ts
+++ b/metmap/src/lib/metronome.ts
@@ -1,0 +1,334 @@
+/**
+ * Metronome Engine - Web Audio API based metronome with customizable sounds
+ *
+ * Uses a "look-ahead" scheduling approach for sample-accurate timing:
+ * 1. JavaScript timer runs every ~25ms (scheduler)
+ * 2. Scheduler looks 100ms ahead and schedules beats in that window
+ * 3. Web Audio API handles precise timing of scheduled sounds
+ */
+
+export type Waveform = 'sine' | 'triangle' | 'square' | 'sawtooth';
+
+export interface ClickSound {
+  frequency: number;      // Hz (200-2000)
+  waveform: Waveform;
+  duration: number;       // ms (20-200)
+  attack: number;         // ms (1-50)
+  release: number;        // ms (10-150)
+  volume: number;         // 0-1
+}
+
+export interface MetronomeConfig {
+  tempo: number;                    // BPM (20-400)
+  beatsPerMeasure: number;          // Time signature numerator (1-16)
+  beatUnit: number;                 // Time signature denominator (1,2,4,8,16)
+  accentPattern: number[];          // Volume multipliers per beat (0-1)
+  clickSound: ClickSound;           // Normal beat sound
+  accentSound: ClickSound;          // Accented beat sound
+  subdivisions: number;             // 1=quarter, 2=eighth, 3=triplet, 4=sixteenth
+}
+
+export interface MetronomeState {
+  isPlaying: boolean;
+  currentBeat: number;              // 0-indexed beat in measure
+  currentSubdivision: number;       // 0-indexed subdivision
+  visualBeatTime: number | null;    // Timestamp for visual sync
+}
+
+export type MetronomeCallback = (state: MetronomeState) => void;
+
+// Sound presets
+export const SOUND_PRESETS: Record<string, { click: ClickSound; accent: ClickSound }> = {
+  classic: {
+    click: { frequency: 800, waveform: 'sine', duration: 50, attack: 2, release: 48, volume: 0.5 },
+    accent: { frequency: 1000, waveform: 'sine', duration: 60, attack: 2, release: 58, volume: 0.7 },
+  },
+  wood: {
+    click: { frequency: 1200, waveform: 'triangle', duration: 30, attack: 1, release: 29, volume: 0.6 },
+    accent: { frequency: 1500, waveform: 'triangle', duration: 40, attack: 1, release: 39, volume: 0.8 },
+  },
+  electronic: {
+    click: { frequency: 600, waveform: 'square', duration: 20, attack: 1, release: 19, volume: 0.4 },
+    accent: { frequency: 900, waveform: 'square', duration: 25, attack: 1, release: 24, volume: 0.6 },
+  },
+  soft: {
+    click: { frequency: 440, waveform: 'sine', duration: 80, attack: 10, release: 70, volume: 0.3 },
+    accent: { frequency: 660, waveform: 'sine', duration: 100, attack: 10, release: 90, volume: 0.5 },
+  },
+  bright: {
+    click: { frequency: 1800, waveform: 'sawtooth', duration: 25, attack: 1, release: 24, volume: 0.35 },
+    accent: { frequency: 2200, waveform: 'sawtooth', duration: 30, attack: 1, release: 29, volume: 0.5 },
+  },
+};
+
+export const DEFAULT_CONFIG: MetronomeConfig = {
+  tempo: 120,
+  beatsPerMeasure: 4,
+  beatUnit: 4,
+  accentPattern: [1, 0.5, 0.5, 0.5],  // Accent on beat 1
+  clickSound: SOUND_PRESETS.classic.click,
+  accentSound: SOUND_PRESETS.classic.accent,
+  subdivisions: 1,
+};
+
+class Metronome {
+  private audioContext: AudioContext | null = null;
+  private config: MetronomeConfig = { ...DEFAULT_CONFIG };
+  private isPlaying = false;
+  private schedulerTimer: ReturnType<typeof setInterval> | null = null;
+  private nextBeatTime = 0;
+  private currentBeat = 0;
+  private currentSubdivision = 0;
+  private callback: MetronomeCallback | null = null;
+
+  // Scheduling constants
+  private readonly SCHEDULE_AHEAD_TIME = 0.1;  // seconds to look ahead
+  private readonly SCHEDULER_INTERVAL = 25;    // ms between scheduler runs
+
+  constructor() {
+    // AudioContext created on first play (user interaction required)
+  }
+
+  private initAudioContext(): boolean {
+    if (this.audioContext) return true;
+
+    try {
+      this.audioContext = new (window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)();
+      return true;
+    } catch (error) {
+      console.error('Failed to create AudioContext:', error);
+      return false;
+    }
+  }
+
+  private playClick(time: number, sound: ClickSound, accentMultiplier: number): void {
+    if (!this.audioContext) return;
+
+    const volume = Math.min(1, Math.max(0, sound.volume * accentMultiplier));
+    if (volume === 0) return;
+
+    const oscillator = this.audioContext.createOscillator();
+    const gainNode = this.audioContext.createGain();
+
+    oscillator.type = sound.waveform;
+    oscillator.frequency.setValueAtTime(sound.frequency, time);
+
+    // Attack-release envelope
+    const attackTime = sound.attack / 1000;
+    const duration = sound.duration / 1000;
+
+    gainNode.gain.setValueAtTime(0, time);
+    gainNode.gain.linearRampToValueAtTime(volume, time + attackTime);
+    gainNode.gain.linearRampToValueAtTime(0, time + duration);
+
+    oscillator.connect(gainNode);
+    gainNode.connect(this.audioContext.destination);
+
+    oscillator.start(time);
+    oscillator.stop(time + duration + 0.01);
+  }
+
+  private scheduleBeats(): void {
+    if (!this.audioContext || !this.isPlaying) return;
+
+    const secondsPerBeat = 60 / this.config.tempo;
+    const secondsPerSubdivision = secondsPerBeat / this.config.subdivisions;
+
+    while (this.nextBeatTime < this.audioContext.currentTime + this.SCHEDULE_AHEAD_TIME) {
+      // Determine if this is an accented beat
+      const beatIndex = this.currentBeat % this.config.beatsPerMeasure;
+      const accentMultiplier = this.config.accentPattern[beatIndex] ?? 0.5;
+
+      // Select sound based on accent level
+      const sound = accentMultiplier >= 0.8 ? this.config.accentSound : this.config.clickSound;
+
+      // Only play on beat if subdivision is 0, otherwise play subdivision
+      const shouldPlay = this.currentSubdivision === 0 || this.config.subdivisions > 1;
+      const subdivisionVolume = this.currentSubdivision === 0 ? 1 : 0.5;
+
+      if (shouldPlay) {
+        this.playClick(this.nextBeatTime, sound, accentMultiplier * subdivisionVolume);
+      }
+
+      // Notify callback for visual sync
+      if (this.callback) {
+        const beatTime = this.nextBeatTime;
+        const state: MetronomeState = {
+          isPlaying: true,
+          currentBeat: this.currentBeat,
+          currentSubdivision: this.currentSubdivision,
+          visualBeatTime: beatTime,
+        };
+
+        // Schedule callback slightly before audio to allow visual prep
+        const delay = Math.max(0, (beatTime - this.audioContext.currentTime) * 1000 - 10);
+        setTimeout(() => this.callback?.(state), delay);
+      }
+
+      // Advance to next subdivision
+      this.nextBeatTime += secondsPerSubdivision;
+      this.currentSubdivision++;
+
+      if (this.currentSubdivision >= this.config.subdivisions) {
+        this.currentSubdivision = 0;
+        this.currentBeat++;
+
+        if (this.currentBeat >= this.config.beatsPerMeasure) {
+          this.currentBeat = 0;
+        }
+      }
+    }
+  }
+
+  start(): boolean {
+    if (this.isPlaying) return true;
+    if (!this.initAudioContext()) return false;
+
+    this.isPlaying = true;
+    this.currentBeat = 0;
+    this.currentSubdivision = 0;
+    this.nextBeatTime = this.audioContext!.currentTime + 0.05; // Small delay to start
+
+    this.schedulerTimer = setInterval(() => this.scheduleBeats(), this.SCHEDULER_INTERVAL);
+
+    if (this.callback) {
+      this.callback({
+        isPlaying: true,
+        currentBeat: 0,
+        currentSubdivision: 0,
+        visualBeatTime: null,
+      });
+    }
+
+    return true;
+  }
+
+  stop(): void {
+    this.isPlaying = false;
+
+    if (this.schedulerTimer) {
+      clearInterval(this.schedulerTimer);
+      this.schedulerTimer = null;
+    }
+
+    if (this.callback) {
+      this.callback({
+        isPlaying: false,
+        currentBeat: 0,
+        currentSubdivision: 0,
+        visualBeatTime: null,
+      });
+    }
+  }
+
+  toggle(): boolean {
+    if (this.isPlaying) {
+      this.stop();
+      return false;
+    } else {
+      return this.start();
+    }
+  }
+
+  setConfig(config: Partial<MetronomeConfig>): void {
+    this.config = { ...this.config, ...config };
+
+    // Clamp tempo to valid range
+    this.config.tempo = Math.min(400, Math.max(20, this.config.tempo));
+
+    // Ensure accent pattern matches beats per measure
+    if (this.config.accentPattern.length !== this.config.beatsPerMeasure) {
+      this.config.accentPattern = Array(this.config.beatsPerMeasure)
+        .fill(0.5)
+        .map((v, i) => i === 0 ? 1 : v);
+    }
+  }
+
+  getConfig(): MetronomeConfig {
+    return { ...this.config };
+  }
+
+  setTempo(bpm: number): void {
+    this.setConfig({ tempo: bpm });
+  }
+
+  setTimeSignature(beatsPerMeasure: number, beatUnit: number): void {
+    const accentPattern = Array(beatsPerMeasure)
+      .fill(0.5)
+      .map((v, i) => i === 0 ? 1 : v);
+    this.setConfig({ beatsPerMeasure, beatUnit, accentPattern });
+  }
+
+  setAccentPattern(pattern: number[]): void {
+    this.setConfig({ accentPattern: pattern });
+  }
+
+  setSound(preset: keyof typeof SOUND_PRESETS): void {
+    const sounds = SOUND_PRESETS[preset];
+    if (sounds) {
+      this.setConfig({
+        clickSound: sounds.click,
+        accentSound: sounds.accent,
+      });
+    }
+  }
+
+  setSubdivisions(subdivisions: number): void {
+    this.setConfig({ subdivisions: Math.min(4, Math.max(1, subdivisions)) });
+  }
+
+  onBeat(callback: MetronomeCallback): void {
+    this.callback = callback;
+  }
+
+  // Tap tempo helper
+  private tapTimes: number[] = [];
+  private readonly TAP_TIMEOUT = 2000; // Reset after 2s of no taps
+
+  tap(): number | null {
+    const now = Date.now();
+
+    // Clear old taps
+    this.tapTimes = this.tapTimes.filter(t => now - t < this.TAP_TIMEOUT);
+    this.tapTimes.push(now);
+
+    if (this.tapTimes.length < 2) return null;
+
+    // Calculate average interval from last 8 taps
+    const recentTaps = this.tapTimes.slice(-8);
+    let totalInterval = 0;
+    for (let i = 1; i < recentTaps.length; i++) {
+      totalInterval += recentTaps[i] - recentTaps[i - 1];
+    }
+    const avgInterval = totalInterval / (recentTaps.length - 1);
+    const bpm = Math.round(60000 / avgInterval);
+
+    // Clamp to valid range
+    const clampedBpm = Math.min(400, Math.max(20, bpm));
+    this.setTempo(clampedBpm);
+
+    return clampedBpm;
+  }
+
+  destroy(): void {
+    this.stop();
+    if (this.audioContext) {
+      this.audioContext.close();
+      this.audioContext = null;
+    }
+  }
+}
+
+// Singleton instance
+let metronomeInstance: Metronome | null = null;
+
+export function getMetronome(): Metronome {
+  if (!metronomeInstance) {
+    metronomeInstance = new Metronome();
+  }
+  return metronomeInstance;
+}
+
+export function createMetronome(): Metronome {
+  return new Metronome();
+}


### PR DESCRIPTION
- Add Web Audio API metronome engine with look-ahead scheduling
- Support 5 click sound presets (classic, wood, electronic, soft, bright)
- Add accent patterns for 10+ time signatures (4/4, 3/4, 6/8, 7/8, etc.)
- Include custom accent pattern editor (tap beats to toggle)
- Support subdivisions (quarter, 8ths, triplets, 16ths)
- Add visual beat indicator with pulse animation
- Include tap tempo feature
- Persist preferences to localStorage
- Integrate collapsible metronome panel in practice page