### PR TITLE
fix(metmap): Run database schema sync on container startup

### DIFF
--- a/metmap/Dockerfile
+++ b/metmap/Dockerfile
@@ -45,8 +45,16 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 
+# Copy Prisma schema and node_modules for db push
+COPY --from=builder /app/prisma ./prisma
+COPY --from=builder /app/node_modules ./node_modules
+
+# Copy entrypoint script
+COPY scripts/entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+
 USER nextjs
 
 EXPOSE 3000
 
-CMD ["node", "server.js"]
+CMD ["./entrypoint.sh"]

--- a/metmap/scripts/entrypoint.sh
+++ b/metmap/scripts/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+# Use db push to sync schema - will create tables if they don't exist
+# This is safe for initial setup and non-breaking changes
+npx prisma db push --skip-generate
+
+echo "Starting Next.js server..."
+exec node server.js


### PR DESCRIPTION
The application was failing with "table public.accounts does not exist" because Prisma migrations were never applied. Add an entrypoint script that runs prisma db push to sync the database schema before starting the Next.js server.