### PR TITLE
fix(metmap): Resolve React hydration errors

### DIFF
--- a/metmap/src/app/layout.tsx
+++ b/metmap/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next';
 import { AuthProvider } from '@/components/auth';
+import { StoreProvider } from '@/components/StoreProvider';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -33,9 +34,11 @@ export default function RootLayout({
     <html lang="en">
       <body className="font-sans antialiased">
         <AuthProvider>
-          <div className="min-h-screen flex flex-col">
-            {children}
-          </div>
+          <StoreProvider>
+            <div className="min-h-screen flex flex-col">
+              {children}
+            </div>
+          </StoreProvider>
         </AuthProvider>
       </body>
     </html>

--- a/metmap/src/app/page.tsx
+++ b/metmap/src/app/page.tsx
@@ -1,15 +1,25 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { Plus, Music, Calendar, Search, MoreVertical } from 'lucide-react';
 import { useMetMapStore, useSongsByLastPracticed } from '@/stores/useMetMapStore';
 import { formatTime, getSongConfidence } from '@/types/metmap';
 import { clsx } from 'clsx';
 
+// Hook to detect when client-side hydration is complete
+function useHasMounted() {
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+  return hasMounted;
+}
+
 export default function Home() {
   const [searchQuery, setSearchQuery] = useState('');
   const [showNewSongModal, setShowNewSongModal] = useState(false);
+  const hasMounted = useHasMounted();
   const songs = useSongsByLastPracticed();
 
   const filteredSongs = songs.filter(
@@ -50,7 +60,22 @@ export default function Home() {
 
       {/* Song List */}
       <div className="flex-1 px-4 py-4">
-        {filteredSongs.length === 0 ? (
+        {!hasMounted ? (
+          // Loading skeleton while hydrating from localStorage
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 animate-pulse">
+                <div className="flex items-start gap-3">
+                  <div className="w-12 h-12 rounded-lg bg-gray-200 dark:bg-gray-700" />
+                  <div className="flex-1">
+                    <div className="h-5 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-2" />
+                    <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : filteredSongs.length === 0 ? (
           <EmptyState onAddSong={() => setShowNewSongModal(true)} />
         ) : (
           <div className="space-y-3">

--- a/metmap/src/components/StoreProvider.tsx
+++ b/metmap/src/components/StoreProvider.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { useStoreHydration } from '@/stores/useMetMapStore';
+
+export function StoreProvider({ children }: { children: React.ReactNode }) {
+  useStoreHydration();
+  return <>{children}</>;
+}

--- a/metmap/src/stores/useMetMapStore.ts
+++ b/metmap/src/stores/useMetMapStore.ts
@@ -2,6 +2,7 @@
 
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { useEffect } from 'react';
 import {
   Song,
   Section,
@@ -319,6 +320,8 @@ export const useMetMapStore = create<MetMapStore>()(
       name: 'metmap-storage',
       storage: createJSONStorage(() => localStorage),
       version: 1,
+      // Skip hydration during SSR to avoid hydration mismatch
+      skipHydration: true,
       // Handle migrations between versions
       migrate: (persistedState, version) => {
         if (version === 0) {
@@ -336,6 +339,16 @@ export const useMetMapStore = create<MetMapStore>()(
     }
   )
 );
+
+/**
+ * Hook to hydrate the store from localStorage on the client.
+ * Call this once in your app's root layout or provider.
+ */
+export function useStoreHydration() {
+  useEffect(() => {
+    useMetMapStore.persist.rehydrate();
+  }, []);
+}
 
 /**
  * Hook to get songs sorted by last practiced (most recent first)


### PR DESCRIPTION
- Add skipHydration to Zustand persist config to prevent SSR/client mismatch
- Create StoreProvider to manually trigger rehydration on client mount
- Add useHasMounted hook in page.tsx to show loading skeleton until hydrated
- Fix formatRelativeDate hydration mismatch by deferring render

Fixes React error #418 (hydration mismatch) caused by:
1. Zustand localStorage state differing between server and client
2. Date calculations producing different results on server vs client