### PR TITLE
feat(metmap): Add Orchid-inspired hardware UI components

### DIFF
--- a/metmap/src/app/song/[id]/practice/page.tsx
+++ b/metmap/src/app/song/[id]/practice/page.tsx
@@ -15,9 +15,11 @@ import {
   Zap,
   Music,
   ChevronDown,
+  Grid3X3,
 } from 'lucide-react';
 import { useMetMapStore } from '@/stores/useMetMapStore';
-import { MetronomeControls } from '@/components/MetronomeControls';
+import { HardwareMetronome } from '@/components/HardwareMetronome';
+import { SectionPadGrid, ConfidenceRating } from '@/components/SectionPadGrid';
 import {
   ConfidenceLevel,
   SECTION_COLORS,
@@ -177,9 +179,9 @@ export default function PracticeModePage() {
     100;
 
   return (
-    <main className="flex-1 flex flex-col bg-gray-900 text-white">
+    <main className="flex-1 flex flex-col bg-hw-charcoal text-white">
       {/* Header */}
-      <header className="flex items-center justify-between px-4 py-3 border-b border-gray-800">
+      <header className="flex items-center justify-between px-4 py-3 border-b border-hw-surface">
         <button
           onClick={() => setShowEndSessionModal(true)}
           className="flex items-center gap-2 text-gray-400 hover:text-white"
@@ -223,9 +225,9 @@ export default function PracticeModePage() {
 
         {/* Progress bar */}
         <div className="w-full max-w-sm mb-8">
-          <div className="h-2 bg-gray-700 rounded-full overflow-hidden">
+          <div className="h-2 bg-hw-surface rounded-full overflow-hidden">
             <div
-              className="h-full bg-metmap-500 transition-all duration-100"
+              className="h-full bg-hw-brass transition-all duration-100"
               style={{ width: `${Math.min(100, Math.max(0, sectionProgress))}%` }}
             />
           </div>
@@ -240,34 +242,22 @@ export default function PracticeModePage() {
           <p className="text-sm text-gray-400 text-center mb-3">
             How confident are you with this section?
           </p>
-          <div className="flex items-center gap-2">
-            {([1, 2, 3, 4, 5] as ConfidenceLevel[]).map((level) => (
-              <button
-                key={level}
-                onClick={() => handleConfidenceChange(level)}
-                className={clsx(
-                  'w-12 h-12 rounded-full text-lg font-bold transition-all tap-target',
-                  level <= currentSection.confidence
-                    ? 'bg-metmap-500 text-white scale-110'
-                    : 'bg-gray-700 text-gray-400 hover:bg-gray-600'
-                )}
-              >
-                {level}
-              </button>
-            ))}
-          </div>
+          <ConfidenceRating
+            value={currentSection.confidence}
+            onChange={handleConfidenceChange}
+          />
         </div>
 
         {/* Notes */}
         {currentSection.notes && (
-          <div className="w-full max-w-sm p-4 bg-gray-800 rounded-xl mb-6">
+          <div className="w-full max-w-sm p-4 bg-hw-surface rounded-xl mb-6 shadow-pad">
             <p className="text-sm text-gray-300">{currentSection.notes}</p>
           </div>
         )}
       </div>
 
       {/* Playback Controls */}
-      <div className="p-4 border-t border-gray-800">
+      <div className="p-4 border-t border-hw-surface">
         {/* Section navigation */}
         <div className="flex items-center justify-center gap-4 mb-4">
           <button
@@ -280,7 +270,7 @@ export default function PracticeModePage() {
 
           <button
             onClick={() => setIsPaused(!isPaused)}
-            className="w-16 h-16 rounded-full bg-metmap-500 hover:bg-metmap-600 flex items-center justify-center tap-target"
+            className="w-16 h-16 rounded-full bg-hw-brass hover:bg-hw-brass/90 shadow-knob active:shadow-knob-pressed flex items-center justify-center tap-target transition-all"
           >
             {isPaused ? (
               <Play className="w-8 h-8 ml-1" />
@@ -307,10 +297,10 @@ export default function PracticeModePage() {
           <button
             onClick={() => setIsLooping(!isLooping)}
             className={clsx(
-              'flex items-center gap-2 px-4 py-2 rounded-lg tap-target',
+              'flex items-center gap-2 px-4 py-2 rounded-lg tap-target transition-all',
               isLooping
-                ? 'bg-metmap-500/20 text-metmap-400'
-                : 'text-gray-400 hover:bg-gray-800'
+                ? 'bg-hw-brass/20 text-hw-brass shadow-pad-active'
+                : 'text-gray-400 hover:bg-gray-800 shadow-pad'
             )}
           >
             <Repeat className="w-5 h-5" />
@@ -320,10 +310,10 @@ export default function PracticeModePage() {
           <button
             onClick={() => setShowMetronome(!showMetronome)}
             className={clsx(
-              'flex items-center gap-2 px-4 py-2 rounded-lg tap-target',
+              'flex items-center gap-2 px-4 py-2 rounded-lg tap-target transition-all',
               showMetronome
-                ? 'bg-blue-500/20 text-blue-400'
-                : 'text-gray-400 hover:bg-gray-800'
+                ? 'bg-hw-orange/20 text-hw-orange shadow-pad-active'
+                : 'text-gray-400 hover:bg-gray-800 shadow-pad'
             )}
           >
             <Music className="w-5 h-5" />
@@ -338,7 +328,7 @@ export default function PracticeModePage() {
 
           <button
             onClick={handleSectionComplete}
-            className="flex items-center gap-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded-lg tap-target"
+            className="flex items-center gap-2 px-4 py-2 bg-section-front hover:bg-section-front/90 rounded-lg tap-target shadow-pad active:shadow-pad-active transition-all"
           >
             <Check className="w-5 h-5" />
             <span className="text-sm">Mark Done</span>
@@ -348,36 +338,29 @@ export default function PracticeModePage() {
         {/* Metronome Panel */}
         {showMetronome && (
           <div className="mt-4">
-            <MetronomeControls />
+            <HardwareMetronome />
           </div>
         )}
       </div>
 
-      {/* Section Quick Nav */}
+      {/* Section Pad Grid */}
       <div className="px-4 pb-4">
-        <div className="flex items-center gap-2 overflow-x-auto pb-2 -mx-4 px-4">
-          {song.sections.map((section, index) => (
-            <button
-              key={section.id}
-              onClick={() => setCurrentSectionIndex(index)}
-              className={clsx(
-                'flex-shrink-0 px-3 py-2 rounded-lg text-sm font-medium transition-all',
-                index === currentSectionIndex
-                  ? 'bg-metmap-500 text-white'
-                  : 'bg-gray-800 text-gray-400 hover:bg-gray-700'
-              )}
-            >
-              {section.name}
-            </button>
-          ))}
-        </div>
+        <SectionPadGrid
+          sections={song.sections}
+          currentSectionIndex={currentSectionIndex}
+          onSectionSelect={setCurrentSectionIndex}
+          onConfidenceChange={(sectionId, confidence) =>
+            updateSectionConfidence(songId, sectionId, confidence)
+          }
+          maxColumns={4}
+        />
       </div>
 
       {/* Weak Sections Suggestion */}
       {weakSections.length > 0 && (
         <div className="px-4 pb-4">
-          <div className="p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-xl">
-            <div className="flex items-center gap-2 text-yellow-400 text-sm mb-2">
+          <div className="p-3 bg-hw-orange/10 border border-hw-orange/30 rounded-xl">
+            <div className="flex items-center gap-2 text-hw-orange text-sm mb-2">
               <Zap className="w-4 h-4" />
               <span className="font-medium">Focus Areas</span>
             </div>
@@ -388,7 +371,7 @@ export default function PracticeModePage() {
                   <button
                     key={section.id}
                     onClick={() => setCurrentSectionIndex(index)}
-                    className="text-xs px-2 py-1 bg-yellow-500/20 text-yellow-300 rounded hover:bg-yellow-500/30"
+                    className="text-xs px-2 py-1 bg-hw-orange/20 text-hw-peach rounded shadow-pad hover:bg-hw-orange/30 active:shadow-pad-active transition-all"
                   >
                     {section.name} ({section.confidence}/5)
                   </button>
@@ -425,7 +408,10 @@ function EndSessionModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/70">
-      <div className="w-full max-w-md bg-gray-800 rounded-t-2xl sm:rounded-2xl">
+      <div className="w-full max-w-md bg-hw-charcoal rounded-t-2xl sm:rounded-2xl overflow-hidden">
+        {/* Brass accent strip */}
+        <div className="h-1.5 bg-gradient-to-r from-hw-brass via-hw-peach to-hw-brass" />
+
         <div className="p-6">
           <h2 className="text-xl font-bold text-white mb-2">End Practice Session</h2>
           <p className="text-gray-400 mb-6">
@@ -434,29 +420,17 @@ function EndSessionModal({
 
           <div className="space-y-4">
             <div>
-              <label className="block text-sm text-gray-400 mb-2">
+              <label className="block text-[10px] uppercase tracking-wider text-gray-500 font-medium mb-2">
                 How did it go?
               </label>
-              <div className="flex items-center gap-2">
-                {([1, 2, 3, 4, 5] as ConfidenceLevel[]).map((level) => (
-                  <button
-                    key={level}
-                    onClick={() => setRating(level)}
-                    className={clsx(
-                      'flex-1 py-3 rounded-lg font-bold transition-all',
-                      rating === level
-                        ? 'bg-metmap-500 text-white'
-                        : 'bg-gray-700 text-gray-400 hover:bg-gray-600'
-                    )}
-                  >
-                    {level}
-                  </button>
-                ))}
-              </div>
+              <ConfidenceRating
+                value={rating || 3}
+                onChange={setRating}
+              />
             </div>
 
             <div>
-              <label className="block text-sm text-gray-400 mb-2">
+              <label className="block text-[10px] uppercase tracking-wider text-gray-500 font-medium mb-2">
                 Session notes (optional)
               </label>
               <textarea
@@ -464,22 +438,22 @@ function EndSessionModal({
                 onChange={(e) => setNotes(e.target.value)}
                 placeholder="What did you work on? Any breakthroughs?"
                 rows={3}
-                className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-metmap-500 resize-none"
+                className="w-full px-4 py-3 bg-hw-surface border border-hw-surface rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-hw-brass resize-none"
               />
             </div>
           </div>
         </div>
 
-        <div className="flex gap-3 p-4 border-t border-gray-700">
+        <div className="flex gap-3 p-4 border-t border-hw-surface">
           <button
             onClick={onCancel}
-            className="flex-1 px-4 py-3 text-gray-400 hover:bg-gray-700 rounded-lg font-medium"
+            className="flex-1 px-4 py-3 text-gray-400 hover:bg-hw-surface rounded-lg font-medium shadow-pad active:shadow-pad-active transition-all"
           >
             Keep Practicing
           </button>
           <button
             onClick={() => onEnd(notes || undefined, rating)}
-            className="flex-1 px-4 py-3 bg-metmap-500 hover:bg-metmap-600 text-white rounded-lg font-medium"
+            className="flex-1 px-4 py-3 bg-hw-brass hover:bg-hw-brass/90 text-hw-charcoal rounded-lg font-medium shadow-pad active:shadow-pad-active transition-all"
           >
             End Session
           </button>

--- a/metmap/src/components/HardwareMetronome.tsx
+++ b/metmap/src/components/HardwareMetronome.tsx
@@ -1,0 +1,482 @@
+'use client';
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { useMetronome, SoundPreset } from '@/hooks/useMetronome';
+import { TIME_SIGNATURES } from '@/lib/accentPatterns';
+import { clsx } from 'clsx';
+
+interface HardwareMetronomeProps {
+  className?: string;
+  onTempoChange?: (bpm: number) => void;
+  compact?: boolean;
+}
+
+/**
+ * Hardware-style Knob Component
+ * Draggable circular control inspired by Orchid MIDI controller
+ */
+function Knob({
+  value,
+  min,
+  max,
+  onChange,
+  size = 'md',
+  color = 'default',
+  label,
+  showValue = true,
+}: {
+  value: number;
+  min: number;
+  max: number;
+  onChange: (value: number) => void;
+  size?: 'sm' | 'md' | 'lg';
+  color?: 'default' | 'orange' | 'brass';
+  label?: string;
+  showValue?: boolean;
+}) {
+  const knobRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
+  const startY = useRef(0);
+  const startValue = useRef(value);
+
+  const sizeClasses = {
+    sm: 'w-10 h-10',
+    md: 'w-14 h-14',
+    lg: 'w-20 h-20',
+  };
+
+  const colorClasses = {
+    default: 'bg-hw-charcoal',
+    orange: 'bg-hw-orange',
+    brass: 'bg-hw-brass',
+  };
+
+  // Calculate rotation angle (270 degree range, from -135 to 135)
+  const percentage = (value - min) / (max - min);
+  const rotation = -135 + percentage * 270;
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    isDragging.current = true;
+    startY.current = e.clientY;
+    startValue.current = value;
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  };
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isDragging.current) return;
+      const deltaY = startY.current - e.clientY;
+      const sensitivity = (max - min) / 200;
+      const newValue = Math.round(
+        Math.min(max, Math.max(min, startValue.current + deltaY * sensitivity))
+      );
+      onChange(newValue);
+    },
+    [min, max, onChange]
+  );
+
+  const handleMouseUp = useCallback(() => {
+    isDragging.current = false;
+    document.removeEventListener('mousemove', handleMouseMove);
+    document.removeEventListener('mouseup', handleMouseUp);
+  }, [handleMouseMove]);
+
+  // Touch support
+  const handleTouchStart = (e: React.TouchEvent) => {
+    isDragging.current = true;
+    startY.current = e.touches[0].clientY;
+    startValue.current = value;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isDragging.current) return;
+    const deltaY = startY.current - e.touches[0].clientY;
+    const sensitivity = (max - min) / 200;
+    const newValue = Math.round(
+      Math.min(max, Math.max(min, startValue.current + deltaY * sensitivity))
+    );
+    onChange(newValue);
+  };
+
+  const handleTouchEnd = () => {
+    isDragging.current = false;
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      {label && (
+        <span className="text-[10px] uppercase tracking-wider text-gray-500 font-medium">
+          {label}
+        </span>
+      )}
+      <div
+        ref={knobRef}
+        className={clsx(
+          sizeClasses[size],
+          colorClasses[color],
+          'rounded-full cursor-grab active:cursor-grabbing',
+          'shadow-knob active:shadow-knob-pressed',
+          'relative select-none transition-shadow'
+        )}
+        onMouseDown={handleMouseDown}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* Knob indicator line */}
+        <div
+          className="absolute inset-2 rounded-full bg-gradient-to-b from-white/10 to-transparent"
+          style={{ transform: `rotate(${rotation}deg)` }}
+        >
+          <div
+            className={clsx(
+              'absolute top-1 left-1/2 -translate-x-1/2 w-1 h-2 rounded-full',
+              color === 'default' ? 'bg-hw-brass' : 'bg-white/80'
+            )}
+          />
+        </div>
+      </div>
+      {showValue && (
+        <span className="text-xs font-mono text-gray-400">{value}</span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * LED Beat Indicator
+ */
+function BeatLED({
+  active,
+  accent,
+  size = 'md',
+}: {
+  active: boolean;
+  accent?: boolean;
+  size?: 'sm' | 'md';
+}) {
+  const sizeClasses = {
+    sm: 'w-2 h-2',
+    md: 'w-3 h-3',
+  };
+
+  return (
+    <div
+      className={clsx(
+        sizeClasses[size],
+        'rounded-full transition-all duration-75',
+        active
+          ? accent
+            ? 'bg-hw-red shadow-lg shadow-hw-red/50'
+            : 'bg-hw-orange shadow-lg shadow-hw-orange/50'
+          : 'bg-gray-700'
+      )}
+    />
+  );
+}
+
+/**
+ * Hardware-style tactile button
+ */
+function HardwareButton({
+  children,
+  onClick,
+  active,
+  color = 'default',
+  size = 'md',
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  active?: boolean;
+  color?: 'default' | 'orange' | 'red' | 'brass';
+  size?: 'sm' | 'md' | 'lg';
+}) {
+  const sizeClasses = {
+    sm: 'px-2 py-1 text-xs',
+    md: 'px-3 py-2 text-sm',
+    lg: 'px-4 py-3 text-base',
+  };
+
+  const colorClasses = {
+    default: active
+      ? 'bg-hw-surface text-white shadow-pad-active'
+      : 'bg-hw-charcoal text-gray-300 shadow-pad hover:bg-hw-surface',
+    orange: active
+      ? 'bg-hw-orange text-white shadow-pad-active'
+      : 'bg-hw-orange/80 text-white shadow-pad hover:bg-hw-orange',
+    red: active
+      ? 'bg-hw-red text-white shadow-pad-active'
+      : 'bg-hw-red/80 text-white shadow-pad hover:bg-hw-red',
+    brass: active
+      ? 'bg-hw-brass text-hw-charcoal shadow-pad-active'
+      : 'bg-hw-brass/80 text-hw-charcoal shadow-pad hover:bg-hw-brass',
+  };
+
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        sizeClasses[size],
+        colorClasses[color],
+        'rounded-lg font-medium transition-all active:scale-95',
+        'min-h-[44px] min-w-[44px]'
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * Main Hardware Metronome Component
+ * Inspired by Orchid MIDI controller aesthetic
+ */
+export function HardwareMetronome({
+  className = '',
+  onTempoChange,
+  compact = false,
+}: HardwareMetronomeProps) {
+  const {
+    isPlaying,
+    tempo,
+    timeSignature,
+    beatsPerMeasure,
+    currentBeat,
+    soundPreset,
+    subdivisions,
+    accentPattern,
+    beatPulse,
+    isDownbeat,
+    toggle,
+    setTempo,
+    setTimeSignature,
+    setSoundPreset,
+    setSubdivisions,
+    tap,
+  } = useMetronome();
+
+  const [showOptions, setShowOptions] = useState(false);
+
+  const handleTempoChange = (bpm: number) => {
+    setTempo(bpm);
+    onTempoChange?.(bpm);
+  };
+
+  const handleTap = () => {
+    const bpm = tap();
+    if (bpm !== null) {
+      onTempoChange?.(bpm);
+    }
+  };
+
+  return (
+    <div
+      className={clsx(
+        'bg-hw-charcoal rounded-2xl overflow-hidden',
+        className
+      )}
+    >
+      {/* Brass accent strip */}
+      <div className="h-1.5 bg-gradient-to-r from-hw-brass via-hw-peach to-hw-brass" />
+
+      <div className="p-4">
+        {/* Beat LED strip */}
+        <div className="flex justify-center gap-2 mb-4">
+          {Array.from({ length: beatsPerMeasure }).map((_, i) => (
+            <BeatLED
+              key={i}
+              active={currentBeat === i && isPlaying}
+              accent={i === 0}
+            />
+          ))}
+        </div>
+
+        {/* Main controls row */}
+        <div className="flex items-center justify-between gap-4 mb-4">
+          {/* BPM Knob */}
+          <Knob
+            value={tempo}
+            min={20}
+            max={300}
+            onChange={handleTempoChange}
+            size="lg"
+            color="brass"
+            label="BPM"
+          />
+
+          {/* Center: Play button and tempo display */}
+          <div className="flex flex-col items-center">
+            <button
+              onClick={toggle}
+              className={clsx(
+                'w-16 h-16 rounded-full flex items-center justify-center',
+                'transition-all duration-75 shadow-knob active:shadow-knob-pressed',
+                isPlaying
+                  ? beatPulse
+                    ? isDownbeat
+                      ? 'bg-hw-red scale-105'
+                      : 'bg-hw-orange scale-102'
+                    : 'bg-hw-surface'
+                  : 'bg-hw-surface hover:bg-gray-600'
+              )}
+            >
+              {isPlaying ? (
+                <svg
+                  className="w-8 h-8 text-white"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <rect x="6" y="5" width="4" height="14" rx="1" />
+                  <rect x="14" y="5" width="4" height="14" rx="1" />
+                </svg>
+              ) : (
+                <svg
+                  className="w-8 h-8 text-white ml-1"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              )}
+            </button>
+            <div className="mt-2 text-center">
+              <div className="text-2xl font-mono font-bold text-white">
+                {tempo}
+              </div>
+              <div className="text-[10px] text-gray-500 uppercase tracking-wider">
+                {timeSignature}
+              </div>
+            </div>
+          </div>
+
+          {/* Subdivisions Knob */}
+          <Knob
+            value={subdivisions}
+            min={1}
+            max={4}
+            onChange={setSubdivisions}
+            size="md"
+            color="orange"
+            label="Sub"
+          />
+        </div>
+
+        {/* Quick tempo buttons */}
+        <div className="flex gap-2 mb-3">
+          <HardwareButton onClick={() => handleTempoChange(tempo - 5)} size="sm">
+            -5
+          </HardwareButton>
+          <HardwareButton onClick={() => handleTempoChange(tempo - 1)} size="sm">
+            -1
+          </HardwareButton>
+          <HardwareButton onClick={handleTap} color="brass" size="sm">
+            TAP
+          </HardwareButton>
+          <HardwareButton onClick={() => handleTempoChange(tempo + 1)} size="sm">
+            +1
+          </HardwareButton>
+          <HardwareButton onClick={() => handleTempoChange(tempo + 5)} size="sm">
+            +5
+          </HardwareButton>
+        </div>
+
+        {/* Options toggle */}
+        <button
+          onClick={() => setShowOptions(!showOptions)}
+          className="w-full py-2 text-xs text-gray-500 hover:text-gray-300 flex items-center justify-center gap-1"
+        >
+          Options
+          <svg
+            className={clsx(
+              'w-3 h-3 transition-transform',
+              showOptions && 'rotate-180'
+            )}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
+
+        {/* Expanded options */}
+        {showOptions && (
+          <div className="mt-3 pt-3 border-t border-gray-700 space-y-4">
+            {/* Time Signature */}
+            <div>
+              <label className="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">
+                Time Signature
+              </label>
+              <div className="flex flex-wrap gap-1">
+                {TIME_SIGNATURES.slice(0, 8).map((ts) => (
+                  <HardwareButton
+                    key={ts.display}
+                    onClick={() => setTimeSignature(ts.display)}
+                    active={timeSignature === ts.display}
+                    size="sm"
+                  >
+                    {ts.display}
+                  </HardwareButton>
+                ))}
+              </div>
+            </div>
+
+            {/* Sound preset */}
+            <div>
+              <label className="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">
+                Sound
+              </label>
+              <div className="flex flex-wrap gap-1">
+                {(['classic', 'wood', 'digital', 'soft'] as SoundPreset[]).map(
+                  (preset) => (
+                    <HardwareButton
+                      key={preset}
+                      onClick={() => setSoundPreset(preset)}
+                      active={soundPreset === preset}
+                      size="sm"
+                    >
+                      {preset}
+                    </HardwareButton>
+                  )
+                )}
+              </div>
+            </div>
+
+            {/* Accent pattern visualizer */}
+            <div>
+              <label className="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">
+                Accent Pattern
+              </label>
+              <div className="flex gap-1">
+                {accentPattern.map((level, i) => (
+                  <div
+                    key={i}
+                    className={clsx(
+                      'flex-1 h-8 rounded flex items-center justify-center text-xs font-mono',
+                      level >= 0.8
+                        ? 'bg-hw-red/30 text-hw-red border border-hw-red/50'
+                        : 'bg-hw-surface text-gray-500'
+                    )}
+                  >
+                    {i + 1}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Bottom brass strip */}
+      <div className="h-1 bg-gradient-to-r from-hw-brass/50 via-hw-brass to-hw-brass/50" />
+    </div>
+  );
+}
+
+export default HardwareMetronome;

--- a/metmap/src/components/SectionPadGrid.tsx
+++ b/metmap/src/components/SectionPadGrid.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import { clsx } from 'clsx';
+import { Section, SECTION_COLORS, ConfidenceLevel } from '@/types/metmap';
+
+interface SectionPadGridProps {
+  sections: Section[];
+  currentSectionIndex: number;
+  onSectionSelect: (index: number) => void;
+  onConfidenceChange?: (sectionId: string, confidence: ConfidenceLevel) => void;
+  className?: string;
+  maxColumns?: number;
+}
+
+/**
+ * Get confidence color based on level
+ */
+function getConfidenceColor(confidence: ConfidenceLevel): string {
+  const colors = {
+    1: '#ef4444', // red
+    2: '#f97316', // orange
+    3: '#eab308', // yellow
+    4: '#84cc16', // lime
+    5: '#22c55e', // green
+  };
+  return colors[confidence];
+}
+
+/**
+ * Individual Section Pad
+ * Tactile, hardware-inspired pad button for section navigation
+ */
+function SectionPad({
+  section,
+  index,
+  isActive,
+  onSelect,
+  onConfidenceChange,
+}: {
+  section: Section;
+  index: number;
+  isActive: boolean;
+  onSelect: () => void;
+  onConfidenceChange?: (confidence: ConfidenceLevel) => void;
+}) {
+  const sectionColor = section.color || SECTION_COLORS[section.type];
+  const confidenceColor = getConfidenceColor(section.confidence);
+
+  return (
+    <button
+      onClick={onSelect}
+      className={clsx(
+        'relative aspect-square rounded-lg transition-all duration-100',
+        'flex flex-col items-center justify-center gap-1 p-2',
+        'min-w-[60px] min-h-[60px]',
+        isActive
+          ? 'shadow-pad-active scale-95 ring-2 ring-hw-brass'
+          : 'shadow-pad hover:scale-[1.02] active:scale-95 active:shadow-pad-active'
+      )}
+      style={{
+        backgroundColor: isActive ? sectionColor : `${sectionColor}40`,
+      }}
+    >
+      {/* Confidence indicator dot */}
+      <div
+        className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full"
+        style={{ backgroundColor: confidenceColor }}
+      />
+
+      {/* Section number */}
+      <span
+        className={clsx(
+          'text-lg font-bold',
+          isActive ? 'text-white' : 'text-white/70'
+        )}
+      >
+        {index + 1}
+      </span>
+
+      {/* Section name (truncated) */}
+      <span
+        className={clsx(
+          'text-[9px] font-medium truncate w-full text-center',
+          isActive ? 'text-white/90' : 'text-white/50'
+        )}
+      >
+        {section.name}
+      </span>
+
+      {/* Active indicator glow */}
+      {isActive && (
+        <div
+          className="absolute inset-0 rounded-lg animate-pulse opacity-30"
+          style={{ boxShadow: `0 0 20px ${sectionColor}` }}
+        />
+      )}
+    </button>
+  );
+}
+
+/**
+ * Section Pad Grid Component
+ * Hardware-style grid of section pads for rapid navigation during practice
+ * Inspired by Orchid MIDI controller pad layout
+ */
+export function SectionPadGrid({
+  sections,
+  currentSectionIndex,
+  onSectionSelect,
+  onConfidenceChange,
+  className = '',
+  maxColumns = 4,
+}: SectionPadGridProps) {
+  if (sections.length === 0) {
+    return (
+      <div className="p-4 text-center text-gray-500 text-sm">
+        No sections to display
+      </div>
+    );
+  }
+
+  // Calculate grid layout
+  const numSections = sections.length;
+  const columns = Math.min(maxColumns, numSections);
+
+  return (
+    <div className={clsx('bg-hw-charcoal rounded-xl p-3', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[10px] uppercase tracking-wider text-gray-500 font-medium">
+          Sections
+        </span>
+        <span className="text-[10px] text-gray-600">
+          {currentSectionIndex + 1} / {sections.length}
+        </span>
+      </div>
+
+      {/* Pad Grid */}
+      <div
+        className="grid gap-2"
+        style={{
+          gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+        }}
+      >
+        {sections.map((section, index) => (
+          <SectionPad
+            key={section.id}
+            section={section}
+            index={index}
+            isActive={index === currentSectionIndex}
+            onSelect={() => onSectionSelect(index)}
+            onConfidenceChange={
+              onConfidenceChange
+                ? (conf) => onConfidenceChange(section.id, conf)
+                : undefined
+            }
+          />
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="mt-3 pt-2 border-t border-gray-700/50">
+        <div className="flex items-center justify-center gap-3 text-[9px] text-gray-500">
+          <div className="flex items-center gap-1">
+            <div className="w-2 h-2 rounded-full bg-red-500" />
+            <span>Needs work</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="w-2 h-2 rounded-full bg-yellow-500" />
+            <span>OK</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="w-2 h-2 rounded-full bg-green-500" />
+            <span>Mastered</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Compact section strip for horizontal scrolling
+ */
+export function SectionStrip({
+  sections,
+  currentSectionIndex,
+  onSectionSelect,
+  className = '',
+}: Omit<SectionPadGridProps, 'maxColumns' | 'onConfidenceChange'>) {
+  return (
+    <div className={clsx('flex gap-1.5 overflow-x-auto pb-1', className)}>
+      {sections.map((section, index) => {
+        const isActive = index === currentSectionIndex;
+        const sectionColor = section.color || SECTION_COLORS[section.type];
+        const confidenceColor = getConfidenceColor(section.confidence);
+
+        return (
+          <button
+            key={section.id}
+            onClick={() => onSectionSelect(index)}
+            className={clsx(
+              'flex-shrink-0 px-3 py-2 rounded-lg transition-all',
+              'flex items-center gap-2 min-h-[44px]',
+              isActive
+                ? 'shadow-pad-active ring-1 ring-hw-brass'
+                : 'shadow-pad hover:scale-[1.02] active:scale-95'
+            )}
+            style={{
+              backgroundColor: isActive ? sectionColor : `${sectionColor}30`,
+            }}
+          >
+            {/* Confidence dot */}
+            <div
+              className="w-2 h-2 rounded-full flex-shrink-0"
+              style={{ backgroundColor: confidenceColor }}
+            />
+
+            <span
+              className={clsx(
+                'text-sm font-medium whitespace-nowrap',
+                isActive ? 'text-white' : 'text-white/70'
+              )}
+            >
+              {section.name}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Confidence rating buttons with hardware aesthetic
+ */
+export function ConfidenceRating({
+  value,
+  onChange,
+  className = '',
+}: {
+  value: ConfidenceLevel;
+  onChange: (level: ConfidenceLevel) => void;
+  className?: string;
+}) {
+  const levels: ConfidenceLevel[] = [1, 2, 3, 4, 5];
+
+  return (
+    <div className={clsx('flex gap-2', className)}>
+      {levels.map((level) => {
+        const isActive = level <= value;
+        const color = getConfidenceColor(level);
+
+        return (
+          <button
+            key={level}
+            onClick={() => onChange(level)}
+            className={clsx(
+              'w-11 h-11 rounded-lg font-bold text-lg transition-all',
+              'min-w-[44px] min-h-[44px]',
+              isActive
+                ? 'shadow-pad-active scale-95'
+                : 'shadow-pad hover:scale-[1.02] active:scale-95 active:shadow-pad-active'
+            )}
+            style={{
+              backgroundColor: isActive ? color : '#3d3d42',
+              color: isActive ? 'white' : '#6b7280',
+            }}
+          >
+            {level}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default SectionPadGrid;

--- a/metmap/tailwind.config.ts
+++ b/metmap/tailwind.config.ts
@@ -9,19 +9,29 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        // MetMap brand colors
+        // MetMap brand colors - Orchid-inspired palette
         metmap: {
-          50: "#f0f9ff",
-          100: "#e0f2fe",
-          200: "#bae6fd",
-          300: "#7dd3fc",
-          400: "#38bdf8",
-          500: "#0ea5e9",
-          600: "#0284c7",
-          700: "#0369a1",
-          800: "#075985",
-          900: "#0c4a6e",
-          950: "#082f49",
+          50: "#fef9f3",
+          100: "#fdf2e3",
+          200: "#fbe4c4",
+          300: "#f8d19b",
+          400: "#f4b96f",
+          500: "#d4a056", // warm brass/gold
+          600: "#b8863d",
+          700: "#96692e",
+          800: "#735122",
+          900: "#503918",
+          950: "#2d200d",
+        },
+        // Hardware accent colors (Orchid-inspired)
+        hw: {
+          orange: "#f5a855", // warm orange knobs
+          peach: "#f8c894",  // peach highlights
+          red: "#e85d4c",    // recording/active
+          charcoal: "#2a2a2f", // dark surface
+          surface: "#3d3d42", // elevated surface
+          brass: "#c9a962",   // brass accent
+          ivory: "#f5f0e6",   // ivory keys
         },
         // Section colors for practice maps
         section: {
@@ -31,6 +41,15 @@ const config: Config = {
           bridge: "#8b5cf6",  // purple for transitions
           outro: "#06b6d4",   // cyan for endings
         },
+      },
+      boxShadow: {
+        'knob': '0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -1px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.1)',
+        'knob-pressed': '0 2px 3px -1px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.2)',
+        'pad': '0 2px 4px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.05)',
+        'pad-active': 'inset 0 2px 4px rgba(0, 0, 0, 0.4)',
+      },
+      borderRadius: {
+        'knob': '50%',
       },
     },
   },


### PR DESCRIPTION
- Add brass/gold color palette and hardware accent colors to Tailwind
- Create HardwareMetronome component with draggable knobs, LEDs, tactile buttons
- Create SectionPadGrid component with confidence indicators and pad-style navigation
- Add ConfidenceRating component with hardware button aesthetic
- Update practice page to use new hardware-styled components
- Apply consistent hw-charcoal, hw-brass, shadow-knob/shadow-pad styling