### PR TITLE
fix(metmap): Remove unused imports and variables

### DIFF
--- a/metmap/src/app/song/[id]/practice/page.tsx
+++ b/metmap/src/app/song/[id]/practice/page.tsx
@@ -15,7 +15,6 @@ import {
   Zap,
   Music,
   ChevronDown,
-  Grid3X3,
 } from 'lucide-react';
 import { useMetMapStore } from '@/stores/useMetMapStore';
 import { HardwareMetronome } from '@/components/HardwareMetronome';

--- a/metmap/src/components/HardwareMetronome.tsx
+++ b/metmap/src/components/HardwareMetronome.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { useMetronome, SoundPreset } from '@/hooks/useMetronome';
 import { TIME_SIGNATURES } from '@/lib/accentPatterns';
 import { clsx } from 'clsx';
@@ -235,7 +235,7 @@ function HardwareButton({
 export function HardwareMetronome({
   className = '',
   onTempoChange,
-  compact = false,
+  compact: _compact = false,
 }: HardwareMetronomeProps) {
   const {
     isPlaying,

--- a/metmap/src/components/SectionPadGrid.tsx
+++ b/metmap/src/components/SectionPadGrid.tsx
@@ -35,7 +35,7 @@ function SectionPad({
   index,
   isActive,
   onSelect,
-  onConfidenceChange,
+  onConfidenceChange: _onConfidenceChange,
 }: {
   section: Section;
   index: number;


### PR DESCRIPTION
- Remove unused Grid3X3 import from practice page
- Remove unused useEffect import from HardwareMetronome
- Prefix unused compact prop with underscore in HardwareMetronome
- Prefix unused onConfidenceChange prop with underscore in SectionPadGrid