### PR TITLE
feat(metmap): Add brass-themed app icons and favicon

### DIFF
--- a/metmap/public/icons/icon.svg
+++ b/metmap/public/icons/icon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="brass" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#d4a056"/>
+      <stop offset="50%" style="stop-color:#c9a962"/>
+      <stop offset="100%" style="stop-color:#b8956e"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="512" height="512" rx="96" fill="#2a2a2f"/>
+  <!-- Metronome shape -->
+  <path d="M256 80 L340 400 L172 400 Z" fill="url(#brass)" opacity="0.9"/>
+  <!-- Pendulum arm -->
+  <line x1="256" y1="120" x2="320" y2="200" stroke="#f5f0e6" stroke-width="12" stroke-linecap="round"/>
+  <!-- Weight -->
+  <circle cx="320" cy="200" r="24" fill="#f5f0e6"/>
+  <!-- Base accent -->
+  <rect x="160" y="380" width="192" height="20" rx="4" fill="#c9a962"/>
+</svg>

--- a/metmap/public/manifest.json
+++ b/metmap/public/manifest.json
@@ -4,25 +4,14 @@
   "description": "Break down songs into sections, track your progress, and master every part with focused practice.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#0a0a0f",
-  "theme_color": "#0ea5e9",
+  "background_color": "#2a2a2f",
+  "theme_color": "#c9a962",
   "orientation": "portrait",
   "icons": [
     {
-      "src": "/icons/icon-192.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "/icons/icon-512.png",
-      "sizes": "512x512",
-      "type": "image/png"
-    },
-    {
-      "src": "/icons/icon-maskable.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable"
+      "src": "/icons/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
     }
   ]
 }

--- a/metmap/src/app/apple-icon.tsx
+++ b/metmap/src/app/apple-icon.tsx
@@ -1,0 +1,48 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const size = { width: 180, height: 180 };
+export const contentType = 'image/png';
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#2a2a2f',
+        }}
+      >
+        {/* Metronome shape */}
+        <svg
+          width="130"
+          height="150"
+          viewBox="0 0 140 160"
+          style={{ position: 'absolute' }}
+        >
+          {/* Triangle body */}
+          <path d="M70 10 L120 150 L20 150 Z" fill="#c9a962" />
+          {/* Pendulum arm */}
+          <line
+            x1="70"
+            y1="30"
+            x2="100"
+            y2="70"
+            stroke="#f5f0e6"
+            strokeWidth="6"
+            strokeLinecap="round"
+          />
+          {/* Weight */}
+          <circle cx="100" cy="70" r="12" fill="#f5f0e6" />
+          {/* Base */}
+          <rect x="15" y="140" width="110" height="12" rx="3" fill="#d4a056" />
+        </svg>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/metmap/src/app/icon.tsx
+++ b/metmap/src/app/icon.tsx
@@ -1,0 +1,49 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const size = { width: 192, height: 192 };
+export const contentType = 'image/png';
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#2a2a2f',
+          borderRadius: '32px',
+        }}
+      >
+        {/* Metronome shape */}
+        <svg
+          width="140"
+          height="160"
+          viewBox="0 0 140 160"
+          style={{ position: 'absolute' }}
+        >
+          {/* Triangle body */}
+          <path d="M70 10 L120 150 L20 150 Z" fill="#c9a962" />
+          {/* Pendulum arm */}
+          <line
+            x1="70"
+            y1="30"
+            x2="100"
+            y2="70"
+            stroke="#f5f0e6"
+            strokeWidth="6"
+            strokeLinecap="round"
+          />
+          {/* Weight */}
+          <circle cx="100" cy="70" r="12" fill="#f5f0e6" />
+          {/* Base */}
+          <rect x="15" y="140" width="110" height="12" rx="3" fill="#d4a056" />
+        </svg>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/metmap/src/app/layout.tsx
+++ b/metmap/src/app/layout.tsx
@@ -20,8 +20,8 @@ export const viewport: Viewport = {
   maximumScale: 1,
   userScalable: false,
   themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
-    { media: '(prefers-color-scheme: dark)', color: '#0a0a0f' },
+    { media: '(prefers-color-scheme: light)', color: '#c9a962' },
+    { media: '(prefers-color-scheme: dark)', color: '#2a2a2f' },
   ],
 };
 


### PR DESCRIPTION
- Add SVG icon for manifest with metronome design in brass colors
- Create dynamic icon.tsx and apple-icon.tsx using Next.js ImageResponse
- Update manifest.json to use SVG icon and brass theme colors
- Update layout.tsx theme colors to match hardware aesthetic