### PR TITLE
fix(metmap): Fix ESLint unused variable errors

### DIFF
--- a/metmap/src/components/HardwareMetronome.tsx
+++ b/metmap/src/components/HardwareMetronome.tsx
@@ -235,7 +235,6 @@ function HardwareButton({
 export function HardwareMetronome({
   className = '',
   onTempoChange,
-  compact: _compact = false,
 }: HardwareMetronomeProps) {
   const {
     isPlaying,

--- a/metmap/src/components/SectionPadGrid.tsx
+++ b/metmap/src/components/SectionPadGrid.tsx
@@ -35,13 +35,11 @@ function SectionPad({
   index,
   isActive,
   onSelect,
-  onConfidenceChange: _onConfidenceChange,
 }: {
   section: Section;
   index: number;
   isActive: boolean;
   onSelect: () => void;
-  onConfidenceChange?: (confidence: ConfidenceLevel) => void;
 }) {
   const sectionColor = section.color || SECTION_COLORS[section.type];
   const confidenceColor = getConfidenceColor(section.confidence);
@@ -107,6 +105,7 @@ export function SectionPadGrid({
   sections,
   currentSectionIndex,
   onSectionSelect,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onConfidenceChange,
   className = '',
   maxColumns = 4,
@@ -149,11 +148,6 @@ export function SectionPadGrid({
             index={index}
             isActive={index === currentSectionIndex}
             onSelect={() => onSectionSelect(index)}
-            onConfidenceChange={
-              onConfidenceChange
-                ? (conf) => onConfidenceChange(section.id, conf)
-                : undefined
-            }
           />
         ))}
       </div>


### PR DESCRIPTION
- Remove unused compact prop from HardwareMetronome
- Remove unused onConfidenceChange prop from SectionPad
- Add eslint-disable for onConfidenceChange in SectionPadGrid (kept for future use)