### PR TITLE
feat(metmap): Add user data sync and settings pages

### DIFF
--- a/metmap/src/app/api/sessions/[id]/route.ts
+++ b/metmap/src/app/api/sessions/[id]/route.ts
@@ -1,0 +1,101 @@
+import { getServerSession } from 'next-auth';
+import { NextRequest, NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * PUT /api/sessions/[id] - Update a practice session (e.g., end it)
+ */
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  const session = await getServerSession(authOptions);
+  const { id } = await params;
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Verify the session belongs to the user
+    const existingSession = await prisma.practiceSession.findFirst({
+      where: {
+        id,
+        userId: session.user.id,
+      },
+    });
+
+    if (!existingSession) {
+      return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { endedAt, duration, sectionsPracticed, notes, rating } = body;
+
+    const practiceSession = await prisma.practiceSession.update({
+      where: { id },
+      data: {
+        endedAt: endedAt ? new Date(endedAt) : existingSession.endedAt,
+        duration: duration ?? existingSession.duration,
+        sectionsPracticed: sectionsPracticed ?? existingSession.sectionsPracticed,
+        notes: notes !== undefined ? (notes || null) : existingSession.notes,
+        rating: rating ?? existingSession.rating,
+      },
+    });
+
+    // Transform to match client-side format
+    const transformedSession = {
+      id: practiceSession.id,
+      songId: practiceSession.songId,
+      startedAt: practiceSession.startedAt.toISOString(),
+      endedAt: practiceSession.endedAt?.toISOString(),
+      duration: practiceSession.duration || 0,
+      sectionsPracticed: practiceSession.sectionsPracticed,
+      notes: practiceSession.notes || undefined,
+      rating: practiceSession.rating as 1 | 2 | 3 | 4 | 5 | undefined,
+    };
+
+    return NextResponse.json(transformedSession);
+  } catch (error) {
+    console.error('Failed to update session:', error);
+    return NextResponse.json({ error: 'Failed to update session' }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/sessions/[id] - Delete a practice session
+ */
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  const session = await getServerSession(authOptions);
+  const { id } = await params;
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Verify the session belongs to the user
+    const existingSession = await prisma.practiceSession.findFirst({
+      where: {
+        id,
+        userId: session.user.id,
+      },
+    });
+
+    if (!existingSession) {
+      return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+    }
+
+    // Delete the session
+    await prisma.practiceSession.delete({
+      where: { id },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Failed to delete session:', error);
+    return NextResponse.json({ error: 'Failed to delete session' }, { status: 500 });
+  }
+}

--- a/metmap/src/app/api/sessions/route.ts
+++ b/metmap/src/app/api/sessions/route.ts
@@ -1,0 +1,121 @@
+import { getServerSession } from 'next-auth';
+import { NextRequest, NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * GET /api/sessions - Get all practice sessions for the authenticated user
+ */
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const songId = searchParams.get('songId');
+
+    const sessions = await prisma.practiceSession.findMany({
+      where: {
+        userId: session.user.id,
+        ...(songId ? { songId } : {}),
+      },
+      orderBy: { startedAt: 'desc' },
+      include: {
+        song: {
+          select: {
+            id: true,
+            title: true,
+            artist: true,
+          },
+        },
+      },
+    });
+
+    // Transform to match client-side format
+    const transformedSessions = sessions.map((s) => ({
+      id: s.id,
+      songId: s.songId,
+      startedAt: s.startedAt.toISOString(),
+      endedAt: s.endedAt?.toISOString(),
+      duration: s.duration || 0,
+      sectionsPracticed: s.sectionsPracticed,
+      notes: s.notes || undefined,
+      rating: s.rating as 1 | 2 | 3 | 4 | 5 | undefined,
+      song: {
+        title: s.song.title,
+        artist: s.song.artist || '',
+      },
+    }));
+
+    return NextResponse.json(transformedSessions);
+  } catch (error) {
+    console.error('Failed to fetch sessions:', error);
+    return NextResponse.json({ error: 'Failed to fetch sessions' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/sessions - Create a new practice session
+ */
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { songId, startedAt, endedAt, duration, sectionsPracticed, notes, rating } = body;
+
+    if (!songId) {
+      return NextResponse.json({ error: 'songId is required' }, { status: 400 });
+    }
+
+    // Verify the song belongs to the user
+    const song = await prisma.song.findFirst({
+      where: {
+        id: songId,
+        userId: session.user.id,
+        deletedAt: null,
+      },
+    });
+
+    if (!song) {
+      return NextResponse.json({ error: 'Song not found' }, { status: 404 });
+    }
+
+    const practiceSession = await prisma.practiceSession.create({
+      data: {
+        songId,
+        userId: session.user.id,
+        startedAt: startedAt ? new Date(startedAt) : new Date(),
+        endedAt: endedAt ? new Date(endedAt) : null,
+        duration: duration || null,
+        sectionsPracticed: sectionsPracticed || [],
+        notes: notes || null,
+        rating: rating || null,
+      },
+    });
+
+    // Transform to match client-side format
+    const transformedSession = {
+      id: practiceSession.id,
+      songId: practiceSession.songId,
+      startedAt: practiceSession.startedAt.toISOString(),
+      endedAt: practiceSession.endedAt?.toISOString(),
+      duration: practiceSession.duration || 0,
+      sectionsPracticed: practiceSession.sectionsPracticed,
+      notes: practiceSession.notes || undefined,
+      rating: practiceSession.rating as 1 | 2 | 3 | 4 | 5 | undefined,
+    };
+
+    return NextResponse.json(transformedSession, { status: 201 });
+  } catch (error) {
+    console.error('Failed to create session:', error);
+    return NextResponse.json({ error: 'Failed to create session' }, { status: 500 });
+  }
+}

--- a/metmap/src/app/api/songs/[id]/route.ts
+++ b/metmap/src/app/api/songs/[id]/route.ts
@@ -1,0 +1,206 @@
+import { getServerSession } from 'next-auth';
+import { NextRequest, NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/songs/[id] - Get a single song by ID
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const session = await getServerSession(authOptions);
+  const { id } = await params;
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const song = await prisma.song.findFirst({
+      where: {
+        id,
+        userId: session.user.id,
+        deletedAt: null,
+      },
+      include: {
+        sections: {
+          where: { deletedAt: null },
+          orderBy: { startTime: 'asc' },
+        },
+      },
+    });
+
+    if (!song) {
+      return NextResponse.json({ error: 'Song not found' }, { status: 404 });
+    }
+
+    // Transform to match client-side format
+    const transformedSong = {
+      id: song.id,
+      title: song.title,
+      artist: song.artist || '',
+      album: song.album || undefined,
+      duration: song.duration || 0,
+      bpm: song.bpm || undefined,
+      key: song.key || undefined,
+      timeSignature: song.timeSignature || '4/4',
+      notes: song.notes || undefined,
+      tags: song.tags,
+      createdAt: song.createdAt.toISOString(),
+      updatedAt: song.updatedAt.toISOString(),
+      lastPracticed: undefined,
+      totalPracticeSessions: 0,
+      sections: song.sections.map((section) => ({
+        id: section.id,
+        name: section.name,
+        type: section.type,
+        startTime: section.startTime,
+        endTime: section.endTime,
+        notes: section.notes || undefined,
+        confidence: section.confidence,
+        practiceCount: 0,
+        lastPracticed: undefined,
+        color: section.color || undefined,
+      })),
+    };
+
+    return NextResponse.json(transformedSong);
+  } catch (error) {
+    console.error('Failed to fetch song:', error);
+    return NextResponse.json({ error: 'Failed to fetch song' }, { status: 500 });
+  }
+}
+
+/**
+ * PUT /api/songs/[id] - Update a song
+ */
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  const session = await getServerSession(authOptions);
+  const { id } = await params;
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // First verify the song belongs to the user
+    const existingSong = await prisma.song.findFirst({
+      where: {
+        id,
+        userId: session.user.id,
+        deletedAt: null,
+      },
+    });
+
+    if (!existingSong) {
+      return NextResponse.json({ error: 'Song not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { title, artist, album, duration, bpm, key, timeSignature, notes, tags } = body;
+
+    const song = await prisma.song.update({
+      where: { id },
+      data: {
+        title: title ?? existingSong.title,
+        artist: artist !== undefined ? (artist || null) : existingSong.artist,
+        album: album !== undefined ? (album || null) : existingSong.album,
+        duration: duration !== undefined ? duration : existingSong.duration,
+        bpm: bpm !== undefined ? (bpm || null) : existingSong.bpm,
+        key: key !== undefined ? (key || null) : existingSong.key,
+        timeSignature: timeSignature ?? existingSong.timeSignature,
+        notes: notes !== undefined ? (notes || null) : existingSong.notes,
+        tags: tags ?? existingSong.tags,
+      },
+      include: {
+        sections: {
+          where: { deletedAt: null },
+          orderBy: { startTime: 'asc' },
+        },
+      },
+    });
+
+    // Transform to match client-side format
+    const transformedSong = {
+      id: song.id,
+      title: song.title,
+      artist: song.artist || '',
+      album: song.album || undefined,
+      duration: song.duration || 0,
+      bpm: song.bpm || undefined,
+      key: song.key || undefined,
+      timeSignature: song.timeSignature || '4/4',
+      notes: song.notes || undefined,
+      tags: song.tags,
+      createdAt: song.createdAt.toISOString(),
+      updatedAt: song.updatedAt.toISOString(),
+      lastPracticed: undefined,
+      totalPracticeSessions: 0,
+      sections: song.sections.map((section) => ({
+        id: section.id,
+        name: section.name,
+        type: section.type,
+        startTime: section.startTime,
+        endTime: section.endTime,
+        notes: section.notes || undefined,
+        confidence: section.confidence,
+        practiceCount: 0,
+        lastPracticed: undefined,
+        color: section.color || undefined,
+      })),
+    };
+
+    return NextResponse.json(transformedSong);
+  } catch (error) {
+    console.error('Failed to update song:', error);
+    return NextResponse.json({ error: 'Failed to update song' }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/songs/[id] - Soft delete a song
+ */
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  const session = await getServerSession(authOptions);
+  const { id } = await params;
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Verify the song belongs to the user
+    const existingSong = await prisma.song.findFirst({
+      where: {
+        id,
+        userId: session.user.id,
+        deletedAt: null,
+      },
+    });
+
+    if (!existingSong) {
+      return NextResponse.json({ error: 'Song not found' }, { status: 404 });
+    }
+
+    // Soft delete the song and its sections
+    const now = new Date();
+    await prisma.$transaction([
+      prisma.song.update({
+        where: { id },
+        data: { deletedAt: now },
+      }),
+      prisma.section.updateMany({
+        where: { songId: id },
+        data: { deletedAt: now },
+      }),
+    ]);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Failed to delete song:', error);
+    return NextResponse.json({ error: 'Failed to delete song' }, { status: 500 });
+  }
+}

--- a/metmap/src/app/api/songs/[id]/sections/[sectionId]/route.ts
+++ b/metmap/src/app/api/songs/[id]/sections/[sectionId]/route.ts
@@ -1,0 +1,123 @@
+import { getServerSession } from 'next-auth';
+import { NextRequest, NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+interface RouteParams {
+  params: Promise<{ id: string; sectionId: string }>;
+}
+
+/**
+ * PUT /api/songs/[id]/sections/[sectionId] - Update a section
+ */
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  const session = await getServerSession(authOptions);
+  const { id: songId, sectionId } = await params;
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Verify the section belongs to the user
+    const existingSection = await prisma.section.findFirst({
+      where: {
+        id: sectionId,
+        songId,
+        userId: session.user.id,
+        deletedAt: null,
+      },
+    });
+
+    if (!existingSection) {
+      return NextResponse.json({ error: 'Section not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { name, type, startTime, endTime, notes, confidence, color, sortOrder } = body;
+
+    const section = await prisma.section.update({
+      where: { id: sectionId },
+      data: {
+        name: name ?? existingSection.name,
+        type: type ?? existingSection.type,
+        startTime: startTime ?? existingSection.startTime,
+        endTime: endTime ?? existingSection.endTime,
+        notes: notes !== undefined ? (notes || null) : existingSection.notes,
+        confidence: confidence ?? existingSection.confidence,
+        color: color !== undefined ? (color || null) : existingSection.color,
+        sortOrder: sortOrder ?? existingSection.sortOrder,
+      },
+    });
+
+    // Update the song's updatedAt timestamp
+    await prisma.song.update({
+      where: { id: songId },
+      data: { updatedAt: new Date() },
+    });
+
+    // Transform to match client-side format
+    const transformedSection = {
+      id: section.id,
+      name: section.name,
+      type: section.type,
+      startTime: section.startTime,
+      endTime: section.endTime,
+      notes: section.notes || undefined,
+      confidence: section.confidence,
+      practiceCount: 0,
+      lastPracticed: undefined,
+      color: section.color || undefined,
+    };
+
+    return NextResponse.json(transformedSection);
+  } catch (error) {
+    console.error('Failed to update section:', error);
+    return NextResponse.json({ error: 'Failed to update section' }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/songs/[id]/sections/[sectionId] - Soft delete a section
+ */
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  const session = await getServerSession(authOptions);
+  const { id: songId, sectionId } = await params;
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Verify the section belongs to the user
+    const existingSection = await prisma.section.findFirst({
+      where: {
+        id: sectionId,
+        songId,
+        userId: session.user.id,
+        deletedAt: null,
+      },
+    });
+
+    if (!existingSection) {
+      return NextResponse.json({ error: 'Section not found' }, { status: 404 });
+    }
+
+    // Soft delete the section
+    await prisma.section.update({
+      where: { id: sectionId },
+      data: { deletedAt: new Date() },
+    });
+
+    // Update the song's updatedAt timestamp
+    await prisma.song.update({
+      where: { id: songId },
+      data: { updatedAt: new Date() },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Failed to delete section:', error);
+    return NextResponse.json({ error: 'Failed to delete section' }, { status: 500 });
+  }
+}

--- a/metmap/src/app/api/songs/[id]/sections/route.ts
+++ b/metmap/src/app/api/songs/[id]/sections/route.ts
@@ -1,0 +1,144 @@
+import { getServerSession } from 'next-auth';
+import { NextRequest, NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/songs/[id]/sections - Get all sections for a song
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const session = await getServerSession(authOptions);
+  const { id: songId } = await params;
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Verify the song belongs to the user
+    const song = await prisma.song.findFirst({
+      where: {
+        id: songId,
+        userId: session.user.id,
+        deletedAt: null,
+      },
+    });
+
+    if (!song) {
+      return NextResponse.json({ error: 'Song not found' }, { status: 404 });
+    }
+
+    const sections = await prisma.section.findMany({
+      where: {
+        songId,
+        deletedAt: null,
+      },
+      orderBy: { startTime: 'asc' },
+    });
+
+    // Transform to match client-side format
+    const transformedSections = sections.map((section) => ({
+      id: section.id,
+      name: section.name,
+      type: section.type,
+      startTime: section.startTime,
+      endTime: section.endTime,
+      notes: section.notes || undefined,
+      confidence: section.confidence,
+      practiceCount: 0,
+      lastPracticed: undefined,
+      color: section.color || undefined,
+    }));
+
+    return NextResponse.json(transformedSections);
+  } catch (error) {
+    console.error('Failed to fetch sections:', error);
+    return NextResponse.json({ error: 'Failed to fetch sections' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/songs/[id]/sections - Create a new section
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const session = await getServerSession(authOptions);
+  const { id: songId } = await params;
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    // Verify the song belongs to the user
+    const song = await prisma.song.findFirst({
+      where: {
+        id: songId,
+        userId: session.user.id,
+        deletedAt: null,
+      },
+    });
+
+    if (!song) {
+      return NextResponse.json({ error: 'Song not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { name, type, startTime, endTime, notes, confidence, color, sortOrder } = body;
+
+    if (!name || startTime === undefined || endTime === undefined) {
+      return NextResponse.json(
+        { error: 'Name, startTime, and endTime are required' },
+        { status: 400 }
+      );
+    }
+
+    // Get the count of existing sections for sortOrder
+    const existingSections = await prisma.section.count({
+      where: { songId, deletedAt: null },
+    });
+
+    const section = await prisma.section.create({
+      data: {
+        songId,
+        userId: session.user.id,
+        name,
+        type: type || 'custom',
+        startTime,
+        endTime,
+        notes: notes || null,
+        confidence: confidence || 3,
+        color: color || null,
+        sortOrder: sortOrder ?? existingSections,
+      },
+    });
+
+    // Update the song's updatedAt timestamp
+    await prisma.song.update({
+      where: { id: songId },
+      data: { updatedAt: new Date() },
+    });
+
+    // Transform to match client-side format
+    const transformedSection = {
+      id: section.id,
+      name: section.name,
+      type: section.type,
+      startTime: section.startTime,
+      endTime: section.endTime,
+      notes: section.notes || undefined,
+      confidence: section.confidence,
+      practiceCount: 0,
+      lastPracticed: undefined,
+      color: section.color || undefined,
+    };
+
+    return NextResponse.json(transformedSection, { status: 201 });
+  } catch (error) {
+    console.error('Failed to create section:', error);
+    return NextResponse.json({ error: 'Failed to create section' }, { status: 500 });
+  }
+}

--- a/metmap/src/app/api/songs/route.ts
+++ b/metmap/src/app/api/songs/route.ts
@@ -1,0 +1,165 @@
+import { getServerSession } from 'next-auth';
+import { NextRequest, NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * GET /api/songs - Get all songs for the authenticated user
+ */
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const songs = await prisma.song.findMany({
+      where: {
+        userId: session.user.id,
+        deletedAt: null,
+      },
+      include: {
+        sections: {
+          where: { deletedAt: null },
+          orderBy: { startTime: 'asc' },
+        },
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    // Transform to match client-side format
+    const transformedSongs = songs.map((song) => ({
+      id: song.id,
+      title: song.title,
+      artist: song.artist || '',
+      album: song.album || undefined,
+      duration: song.duration || 0,
+      bpm: song.bpm || undefined,
+      key: song.key || undefined,
+      timeSignature: song.timeSignature || '4/4',
+      notes: song.notes || undefined,
+      tags: song.tags,
+      createdAt: song.createdAt.toISOString(),
+      updatedAt: song.updatedAt.toISOString(),
+      lastPracticed: undefined, // Will be computed from sessions
+      totalPracticeSessions: 0, // Will be computed from sessions
+      sections: song.sections.map((section) => ({
+        id: section.id,
+        name: section.name,
+        type: section.type as 'intro' | 'verse' | 'pre-chorus' | 'chorus' | 'bridge' | 'solo' | 'breakdown' | 'outro' | 'custom',
+        startTime: section.startTime,
+        endTime: section.endTime,
+        notes: section.notes || undefined,
+        confidence: section.confidence as 1 | 2 | 3 | 4 | 5,
+        practiceCount: 0, // Will be computed from sessions
+        lastPracticed: undefined,
+        color: section.color || undefined,
+      })),
+    }));
+
+    return NextResponse.json(transformedSongs);
+  } catch (error) {
+    console.error('Failed to fetch songs:', error);
+    return NextResponse.json({ error: 'Failed to fetch songs' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/songs - Create a new song
+ */
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { title, artist, album, duration, bpm, key, timeSignature, notes, tags, sections } = body;
+
+    if (!title) {
+      return NextResponse.json({ error: 'Title is required' }, { status: 400 });
+    }
+
+    const song = await prisma.song.create({
+      data: {
+        userId: session.user.id,
+        title,
+        artist: artist || null,
+        album: album || null,
+        duration: duration || null,
+        bpm: bpm || null,
+        key: key || null,
+        timeSignature: timeSignature || '4/4',
+        notes: notes || null,
+        tags: tags || [],
+        sections: sections?.length
+          ? {
+              create: sections.map((s: {
+                name: string;
+                type?: string;
+                startTime: number;
+                endTime: number;
+                notes?: string;
+                confidence?: number;
+                color?: string;
+                sortOrder?: number;
+              }, index: number) => ({
+                userId: session.user.id,
+                name: s.name,
+                type: s.type || 'custom',
+                startTime: s.startTime,
+                endTime: s.endTime,
+                notes: s.notes || null,
+                confidence: s.confidence || 3,
+                color: s.color || null,
+                sortOrder: s.sortOrder ?? index,
+              })),
+            }
+          : undefined,
+      },
+      include: {
+        sections: {
+          orderBy: { startTime: 'asc' },
+        },
+      },
+    });
+
+    // Transform to match client-side format
+    const transformedSong = {
+      id: song.id,
+      title: song.title,
+      artist: song.artist || '',
+      album: song.album || undefined,
+      duration: song.duration || 0,
+      bpm: song.bpm || undefined,
+      key: song.key || undefined,
+      timeSignature: song.timeSignature || '4/4',
+      notes: song.notes || undefined,
+      tags: song.tags,
+      createdAt: song.createdAt.toISOString(),
+      updatedAt: song.updatedAt.toISOString(),
+      lastPracticed: undefined,
+      totalPracticeSessions: 0,
+      sections: song.sections.map((section) => ({
+        id: section.id,
+        name: section.name,
+        type: section.type as 'intro' | 'verse' | 'pre-chorus' | 'chorus' | 'bridge' | 'solo' | 'breakdown' | 'outro' | 'custom',
+        startTime: section.startTime,
+        endTime: section.endTime,
+        notes: section.notes || undefined,
+        confidence: section.confidence as 1 | 2 | 3 | 4 | 5,
+        practiceCount: 0,
+        lastPracticed: undefined,
+        color: section.color || undefined,
+      })),
+    };
+
+    return NextResponse.json(transformedSong, { status: 201 });
+  } catch (error) {
+    console.error('Failed to create song:', error);
+    return NextResponse.json({ error: 'Failed to create song' }, { status: 500 });
+  }
+}

--- a/metmap/src/app/api/sync/route.ts
+++ b/metmap/src/app/api/sync/route.ts
@@ -1,0 +1,384 @@
+import { getServerSession } from 'next-auth';
+import { NextRequest, NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+interface LocalStorageSong {
+  id: string;
+  title: string;
+  artist: string;
+  album?: string;
+  duration: number;
+  bpm?: number;
+  key?: string;
+  timeSignature?: string;
+  notes?: string;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+  lastPracticed?: string;
+  totalPracticeSessions: number;
+  sections: Array<{
+    id: string;
+    name: string;
+    type: string;
+    startTime: number;
+    endTime: number;
+    notes?: string;
+    confidence: number;
+    practiceCount: number;
+    lastPracticed?: string;
+    color?: string;
+  }>;
+}
+
+interface LocalStorageSession {
+  id: string;
+  songId: string;
+  startedAt: string;
+  endedAt?: string;
+  duration: number;
+  sectionsPracticed: string[];
+  notes?: string;
+  rating?: number;
+}
+
+interface SyncRequest {
+  songs?: LocalStorageSong[];
+  sessions?: LocalStorageSession[];
+  lastSyncedAt?: string;
+}
+
+/**
+ * POST /api/sync - Sync localStorage data to the database
+ *
+ * This endpoint handles bidirectional sync between localStorage and the database.
+ * It uploads local data and returns the merged result.
+ */
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const body: SyncRequest = await request.json();
+    const { songs: localSongs = [], sessions: localSessions = [] } = body;
+
+    // Map to track local ID -> database ID for songs
+    const songIdMap = new Map<string, string>();
+
+    // Process songs
+    for (const localSong of localSongs) {
+      // Check if this song already exists (by matching title + artist for the user)
+      const existingSong = await prisma.song.findFirst({
+        where: {
+          userId: session.user.id,
+          title: localSong.title,
+          artist: localSong.artist || null,
+          deletedAt: null,
+        },
+      });
+
+      if (existingSong) {
+        // Update existing song if local version is newer
+        const localUpdatedAt = new Date(localSong.updatedAt);
+        if (localUpdatedAt > existingSong.updatedAt) {
+          await prisma.song.update({
+            where: { id: existingSong.id },
+            data: {
+              album: localSong.album || null,
+              duration: localSong.duration || null,
+              bpm: localSong.bpm || null,
+              key: localSong.key || null,
+              timeSignature: localSong.timeSignature || '4/4',
+              notes: localSong.notes || null,
+              tags: localSong.tags || [],
+              updatedAt: localUpdatedAt,
+            },
+          });
+        }
+        songIdMap.set(localSong.id, existingSong.id);
+
+        // Sync sections for existing song
+        for (const localSection of localSong.sections) {
+          // Try to find matching section by name and time range
+          const existingSection = await prisma.section.findFirst({
+            where: {
+              songId: existingSong.id,
+              name: localSection.name,
+              deletedAt: null,
+            },
+          });
+
+          if (existingSection) {
+            // Update if confidence changed
+            if (localSection.confidence !== existingSection.confidence) {
+              await prisma.section.update({
+                where: { id: existingSection.id },
+                data: {
+                  confidence: localSection.confidence,
+                  startTime: localSection.startTime,
+                  endTime: localSection.endTime,
+                  notes: localSection.notes || null,
+                  color: localSection.color || null,
+                },
+              });
+            }
+          } else {
+            // Create new section
+            await prisma.section.create({
+              data: {
+                songId: existingSong.id,
+                userId: session.user.id,
+                name: localSection.name,
+                type: localSection.type || 'custom',
+                startTime: localSection.startTime,
+                endTime: localSection.endTime,
+                notes: localSection.notes || null,
+                confidence: localSection.confidence || 3,
+                color: localSection.color || null,
+              },
+            });
+          }
+        }
+      } else {
+        // Create new song
+        const newSong = await prisma.song.create({
+          data: {
+            userId: session.user.id,
+            title: localSong.title,
+            artist: localSong.artist || null,
+            album: localSong.album || null,
+            duration: localSong.duration || null,
+            bpm: localSong.bpm || null,
+            key: localSong.key || null,
+            timeSignature: localSong.timeSignature || '4/4',
+            notes: localSong.notes || null,
+            tags: localSong.tags || [],
+            createdAt: new Date(localSong.createdAt),
+            updatedAt: new Date(localSong.updatedAt),
+            sections: {
+              create: localSong.sections.map((s, index) => ({
+                userId: session.user.id,
+                name: s.name,
+                type: s.type || 'custom',
+                startTime: s.startTime,
+                endTime: s.endTime,
+                notes: s.notes || null,
+                confidence: s.confidence || 3,
+                color: s.color || null,
+                sortOrder: index,
+              })),
+            },
+          },
+        });
+        songIdMap.set(localSong.id, newSong.id);
+      }
+    }
+
+    // Process practice sessions
+    for (const localSession of localSessions) {
+      // Map the songId to the database ID
+      const dbSongId = songIdMap.get(localSession.songId);
+      if (!dbSongId) {
+        // Try to find the song by the original ID (if it was already synced)
+        const existingSong = await prisma.song.findFirst({
+          where: {
+            userId: session.user.id,
+            deletedAt: null,
+          },
+        });
+        if (!existingSong) continue;
+      }
+
+      const songId = dbSongId || localSession.songId;
+
+      // Check if this session already exists (by matching startedAt)
+      const existingSessionRecord = await prisma.practiceSession.findFirst({
+        where: {
+          userId: session.user.id,
+          songId,
+          startedAt: new Date(localSession.startedAt),
+        },
+      });
+
+      if (!existingSessionRecord) {
+        // Create new practice session
+        await prisma.practiceSession.create({
+          data: {
+            songId,
+            userId: session.user.id,
+            startedAt: new Date(localSession.startedAt),
+            endedAt: localSession.endedAt ? new Date(localSession.endedAt) : null,
+            duration: localSession.duration || null,
+            sectionsPracticed: localSession.sectionsPracticed || [],
+            notes: localSession.notes || null,
+            rating: localSession.rating || null,
+          },
+        });
+      }
+    }
+
+    // Fetch all data to return to client
+    const dbSongs = await prisma.song.findMany({
+      where: {
+        userId: session.user.id,
+        deletedAt: null,
+      },
+      include: {
+        sections: {
+          where: { deletedAt: null },
+          orderBy: { startTime: 'asc' },
+        },
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    const dbSessions = await prisma.practiceSession.findMany({
+      where: {
+        userId: session.user.id,
+      },
+      orderBy: { startedAt: 'desc' },
+    });
+
+    // Transform to match client-side format
+    const transformedSongs = dbSongs.map((song) => ({
+      id: song.id,
+      title: song.title,
+      artist: song.artist || '',
+      album: song.album || undefined,
+      duration: song.duration || 0,
+      bpm: song.bpm || undefined,
+      key: song.key || undefined,
+      timeSignature: song.timeSignature || '4/4',
+      notes: song.notes || undefined,
+      tags: song.tags,
+      createdAt: song.createdAt.toISOString(),
+      updatedAt: song.updatedAt.toISOString(),
+      lastPracticed: undefined,
+      totalPracticeSessions: dbSessions.filter((s) => s.songId === song.id).length,
+      sections: song.sections.map((section) => ({
+        id: section.id,
+        name: section.name,
+        type: section.type,
+        startTime: section.startTime,
+        endTime: section.endTime,
+        notes: section.notes || undefined,
+        confidence: section.confidence,
+        practiceCount: 0,
+        lastPracticed: undefined,
+        color: section.color || undefined,
+      })),
+    }));
+
+    const transformedSessions = dbSessions.map((s) => ({
+      id: s.id,
+      songId: s.songId,
+      startedAt: s.startedAt.toISOString(),
+      endedAt: s.endedAt?.toISOString(),
+      duration: s.duration || 0,
+      sectionsPracticed: s.sectionsPracticed,
+      notes: s.notes || undefined,
+      rating: s.rating || undefined,
+    }));
+
+    return NextResponse.json({
+      success: true,
+      syncedAt: new Date().toISOString(),
+      data: {
+        songs: transformedSongs,
+        sessions: transformedSessions,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to sync data:', error);
+    return NextResponse.json({ error: 'Failed to sync data' }, { status: 500 });
+  }
+}
+
+/**
+ * GET /api/sync - Get the current sync status and all user data
+ */
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const songs = await prisma.song.findMany({
+      where: {
+        userId: session.user.id,
+        deletedAt: null,
+      },
+      include: {
+        sections: {
+          where: { deletedAt: null },
+          orderBy: { startTime: 'asc' },
+        },
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    const sessions = await prisma.practiceSession.findMany({
+      where: {
+        userId: session.user.id,
+      },
+      orderBy: { startedAt: 'desc' },
+    });
+
+    // Transform to match client-side format
+    const transformedSongs = songs.map((song) => ({
+      id: song.id,
+      title: song.title,
+      artist: song.artist || '',
+      album: song.album || undefined,
+      duration: song.duration || 0,
+      bpm: song.bpm || undefined,
+      key: song.key || undefined,
+      timeSignature: song.timeSignature || '4/4',
+      notes: song.notes || undefined,
+      tags: song.tags,
+      createdAt: song.createdAt.toISOString(),
+      updatedAt: song.updatedAt.toISOString(),
+      lastPracticed: undefined,
+      totalPracticeSessions: sessions.filter((s) => s.songId === song.id).length,
+      sections: song.sections.map((section) => ({
+        id: section.id,
+        name: section.name,
+        type: section.type,
+        startTime: section.startTime,
+        endTime: section.endTime,
+        notes: section.notes || undefined,
+        confidence: section.confidence,
+        practiceCount: 0,
+        lastPracticed: undefined,
+        color: section.color || undefined,
+      })),
+    }));
+
+    const transformedSessions = sessions.map((s) => ({
+      id: s.id,
+      songId: s.songId,
+      startedAt: s.startedAt.toISOString(),
+      endedAt: s.endedAt?.toISOString(),
+      duration: s.duration || 0,
+      sectionsPracticed: s.sectionsPracticed,
+      notes: s.notes || undefined,
+      rating: s.rating || undefined,
+    }));
+
+    return NextResponse.json({
+      data: {
+        songs: transformedSongs,
+        sessions: transformedSessions,
+      },
+    });
+  } catch (error) {
+    console.error('Failed to fetch sync data:', error);
+    return NextResponse.json({ error: 'Failed to fetch data' }, { status: 500 });
+  }
+}

--- a/metmap/src/app/auth/welcome/page.tsx
+++ b/metmap/src/app/auth/welcome/page.tsx
@@ -19,19 +19,19 @@ export default function WelcomePage() {
 
   if (status === 'loading') {
     return (
-      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
-        <div className="animate-spin h-8 w-8 border-2 border-metmap-500 border-t-transparent rounded-full" />
+      <div className="min-h-screen bg-hw-charcoal flex items-center justify-center">
+        <div className="animate-spin h-8 w-8 border-2 border-hw-brass border-t-transparent rounded-full" />
       </div>
     );
   }
 
   if (!session) {
     return (
-      <div className="min-h-screen bg-gray-950 flex flex-col items-center justify-center px-4 py-12">
+      <div className="min-h-screen bg-hw-charcoal flex flex-col items-center justify-center px-4 py-12">
         <p className="text-gray-400 mb-4">You need to be signed in to view this page.</p>
         <Link
           href="/auth/login"
-          className="px-4 py-2 bg-metmap-500 hover:bg-metmap-600 text-white rounded-lg"
+          className="px-4 py-2 bg-hw-brass hover:bg-hw-brass/90 text-hw-charcoal font-medium rounded-lg shadow-pad"
         >
           Sign in
         </Link>
@@ -40,13 +40,19 @@ export default function WelcomePage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 flex flex-col items-center justify-center px-4 py-12">
+    <div className="min-h-screen bg-hw-charcoal flex flex-col items-center justify-center px-4 py-12">
       <Link href="/" className="flex items-center gap-2 mb-8">
-        <Music className="w-8 h-8 text-metmap-500" />
-        <span className="text-2xl font-bold text-white">MetMap</span>
+        <div className="w-10 h-10 rounded-lg bg-hw-brass flex items-center justify-center shadow-knob">
+          <span className="text-hw-charcoal font-bold text-lg">M</span>
+        </div>
+        <span className="text-2xl font-bold text-white">
+          <span className="text-hw-brass">Met</span>Map
+        </span>
       </Link>
 
-      <div className="bg-gray-900 rounded-2xl p-8 shadow-xl max-w-md w-full text-center">
+      <div className="bg-hw-surface rounded-2xl overflow-hidden shadow-xl max-w-md w-full text-center">
+        <div className="h-1.5 bg-gradient-to-r from-hw-brass via-hw-peach to-hw-brass" />
+        <div className="p-8">
         <div className="bg-green-500/10 p-4 rounded-full inline-flex mb-6">
           <CheckCircle2 className="w-12 h-12 text-green-500" />
         </div>
@@ -55,16 +61,16 @@ export default function WelcomePage() {
           Welcome{session.user?.name ? `, ${session.user.name.split(' ')[0]}` : ''}!
         </h1>
         <p className="text-gray-400 mb-6">
-          Your account is set up. Your practice data will now sync across all your devices.
+          Your account is set up. You can now save songs and track your practice progress.
         </p>
 
         {hasLocalData && (
-          <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-4 mb-6">
-            <h2 className="text-sm font-medium text-blue-400 mb-1">
-              Existing data found
+          <div className="bg-hw-brass/10 border border-hw-brass/20 rounded-lg p-4 mb-6">
+            <h2 className="text-sm font-medium text-hw-brass mb-1">
+              Local data found
             </h2>
             <p className="text-xs text-gray-400">
-              We found practice data on this device. It will be synced to your account automatically.
+              You have practice data saved on this device. Use the sync button to save it to your account.
             </p>
           </div>
         )}
@@ -72,11 +78,12 @@ export default function WelcomePage() {
         <div className="space-y-3">
           <Link
             href="/"
-            className="w-full flex items-center justify-center gap-2 py-3 px-4 bg-metmap-500 hover:bg-metmap-600 text-white font-medium rounded-lg transition-colors"
+            className="w-full flex items-center justify-center gap-2 py-3 px-4 bg-hw-brass hover:bg-hw-brass/90 text-hw-charcoal font-medium rounded-lg transition-all shadow-pad active:shadow-pad-active"
           >
             Start practicing
             <ArrowRight className="w-4 h-4" />
           </Link>
+        </div>
         </div>
       </div>
     </div>

--- a/metmap/src/app/page.tsx
+++ b/metmap/src/app/page.tsx
@@ -2,10 +2,11 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { Plus, Music, Calendar, Search, MoreVertical } from 'lucide-react';
+import { Plus, Music, Calendar, Search, MoreVertical, Settings } from 'lucide-react';
 import { useMetMapStore, useSongsByLastPracticed } from '@/stores/useMetMapStore';
 import { formatTime, getSongConfidence } from '@/types/metmap';
 import { clsx } from 'clsx';
+import { SyncButton } from '@/components/SyncButton';
 
 // Hook to detect when client-side hydration is complete
 function useHasMounted() {
@@ -36,13 +37,22 @@ export default function Home() {
           <h1 className="text-2xl font-bold text-white flex items-center gap-2">
             <span className="text-hw-brass">Met</span>Map
           </h1>
-          <button
-            onClick={() => setShowNewSongModal(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-hw-brass hover:bg-hw-brass/90 text-hw-charcoal rounded-lg font-medium transition-all shadow-pad active:shadow-pad-active tap-target"
-          >
-            <Plus className="w-5 h-5" />
-            <span className="hidden sm:inline">New Song</span>
-          </button>
+          <div className="flex items-center gap-2">
+            <SyncButton compact />
+            <Link
+              href="/settings"
+              className="p-2 text-gray-400 hover:text-white rounded-lg hover:bg-hw-surface transition-colors"
+            >
+              <Settings className="w-5 h-5" />
+            </Link>
+            <button
+              onClick={() => setShowNewSongModal(true)}
+              className="flex items-center gap-2 px-4 py-2 bg-hw-brass hover:bg-hw-brass/90 text-hw-charcoal rounded-lg font-medium transition-all shadow-pad active:shadow-pad-active tap-target"
+            >
+              <Plus className="w-5 h-5" />
+              <span className="hidden sm:inline">New Song</span>
+            </button>
+          </div>
         </div>
 
         {/* Search */}

--- a/metmap/src/app/settings/account/page.tsx
+++ b/metmap/src/app/settings/account/page.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useSession, signOut } from 'next-auth/react';
+import { ArrowLeft, Mail, User, Calendar, Shield, LogOut } from 'lucide-react';
+
+export default function AccountPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  // Redirect to login if not authenticated
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/auth/login?callbackUrl=/settings/account');
+    }
+  }, [status, router]);
+
+  const handleSignOut = async () => {
+    await signOut({ callbackUrl: '/' });
+  };
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen bg-hw-charcoal flex items-center justify-center">
+        <div className="animate-spin h-8 w-8 border-2 border-hw-brass border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  if (!session?.user) {
+    return null;
+  }
+
+  const user = session.user;
+  const createdAt = new Date().toLocaleDateString(); // We don't have createdAt in session
+
+  return (
+    <div className="min-h-screen bg-hw-charcoal">
+      {/* Header */}
+      <header className="sticky top-0 z-10 bg-hw-charcoal/95 backdrop-blur-sm border-b border-hw-surface px-4 py-4">
+        <div className="flex items-center gap-4 max-w-2xl mx-auto">
+          <Link
+            href="/settings"
+            className="p-2 -ml-2 text-gray-400 hover:text-white rounded-lg hover:bg-hw-surface transition-colors"
+          >
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <h1 className="text-xl font-bold text-white">Account</h1>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-6 space-y-6">
+        {/* Profile Card */}
+        <div className="bg-hw-surface rounded-xl p-6">
+          <div className="flex items-center gap-4 mb-6">
+            <div className="w-20 h-20 rounded-full bg-hw-brass flex items-center justify-center shadow-knob">
+              {user.image ? (
+                <img
+                  src={user.image}
+                  alt={user.name || 'User'}
+                  className="w-20 h-20 rounded-full"
+                />
+              ) : (
+                <span className="text-hw-charcoal font-bold text-3xl">
+                  {(user.name || user.email || 'U')[0].toUpperCase()}
+                </span>
+              )}
+            </div>
+            <div>
+              <h2 className="text-2xl font-bold text-white">
+                {user.name || 'User'}
+              </h2>
+              <p className="text-gray-400">{user.email}</p>
+            </div>
+          </div>
+
+          <div className="h-px bg-hw-charcoal mb-6" />
+
+          <div className="space-y-4">
+            <div className="flex items-center gap-4">
+              <div className="w-10 h-10 rounded-lg bg-hw-charcoal flex items-center justify-center">
+                <User className="w-5 h-5 text-gray-400" />
+              </div>
+              <div className="flex-1">
+                <p className="text-[10px] uppercase tracking-wider text-gray-500 font-medium">
+                  Name
+                </p>
+                <p className="text-white">{user.name || 'Not set'}</p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-4">
+              <div className="w-10 h-10 rounded-lg bg-hw-charcoal flex items-center justify-center">
+                <Mail className="w-5 h-5 text-gray-400" />
+              </div>
+              <div className="flex-1">
+                <p className="text-[10px] uppercase tracking-wider text-gray-500 font-medium">
+                  Email
+                </p>
+                <p className="text-white">{user.email}</p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-4">
+              <div className="w-10 h-10 rounded-lg bg-hw-charcoal flex items-center justify-center">
+                <Calendar className="w-5 h-5 text-gray-400" />
+              </div>
+              <div className="flex-1">
+                <p className="text-[10px] uppercase tracking-wider text-gray-500 font-medium">
+                  Member since
+                </p>
+                <p className="text-white">{createdAt}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Connected Accounts */}
+        <section>
+          <h2 className="text-[10px] uppercase tracking-wider text-gray-500 font-medium mb-3 px-1">
+            Connected Accounts
+          </h2>
+          <div className="bg-hw-surface rounded-xl overflow-hidden divide-y divide-hw-charcoal">
+            <div className="flex items-center gap-4 p-4">
+              <div className="w-10 h-10 rounded-lg bg-hw-charcoal flex items-center justify-center">
+                <Shield className="w-5 h-5 text-gray-400" />
+              </div>
+              <div className="flex-1">
+                <p className="font-medium text-white">Email & Password</p>
+                <p className="text-sm text-gray-400">Primary login method</p>
+              </div>
+              <span className="text-xs text-green-500 bg-green-500/10 px-2 py-1 rounded">
+                Active
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {/* Flux Studio Connection */}
+        <section>
+          <h2 className="text-[10px] uppercase tracking-wider text-gray-500 font-medium mb-3 px-1">
+            Flux Studio
+          </h2>
+          <div className="bg-hw-surface rounded-xl p-4">
+            <div className="flex items-center gap-4">
+              <div className="w-10 h-10 rounded-lg bg-hw-brass/20 flex items-center justify-center">
+                <span className="text-hw-brass font-bold">F</span>
+              </div>
+              <div className="flex-1">
+                <p className="font-medium text-white">Flux Studio Account</p>
+                <p className="text-sm text-gray-400">
+                  Your MetMap account works across all Flux Studio apps
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Danger Zone */}
+        <section>
+          <h2 className="text-[10px] uppercase tracking-wider text-gray-500 font-medium mb-3 px-1">
+            Account Actions
+          </h2>
+          <div className="bg-hw-surface rounded-xl overflow-hidden divide-y divide-hw-charcoal">
+            <button
+              onClick={handleSignOut}
+              className="flex items-center gap-4 p-4 w-full text-left hover:bg-hw-charcoal/50 transition-colors"
+            >
+              <div className="w-10 h-10 rounded-lg bg-hw-charcoal flex items-center justify-center">
+                <LogOut className="w-5 h-5 text-gray-400" />
+              </div>
+              <div className="flex-1">
+                <p className="font-medium text-white">Sign out</p>
+                <p className="text-sm text-gray-400">
+                  Sign out of your account on this device
+                </p>
+              </div>
+            </button>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/metmap/src/app/settings/page.tsx
+++ b/metmap/src/app/settings/page.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import Link from 'next/link';
+import { useSession, signOut } from 'next-auth/react';
+import {
+  ArrowLeft,
+  User,
+  Cloud,
+  Bell,
+  Palette,
+  HelpCircle,
+  LogOut,
+  ChevronRight,
+  Trash2,
+} from 'lucide-react';
+import { useSync } from '@/hooks/useSync';
+import { useMetMapStore } from '@/stores/useMetMapStore';
+
+export default function SettingsPage() {
+  const { data: session, status } = useSession();
+  const { sync, syncStatus, isAuthenticated, lastSyncedAt } = useSync();
+  const clearAllData = useMetMapStore((state) => state.clearAllData);
+
+  const handleSignOut = async () => {
+    await signOut({ callbackUrl: '/' });
+  };
+
+  const handleClearData = () => {
+    if (
+      confirm(
+        'Are you sure you want to clear all local data? This cannot be undone. If you have synced data, you can restore it by signing in again.'
+      )
+    ) {
+      clearAllData();
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-hw-charcoal">
+      {/* Header */}
+      <header className="sticky top-0 z-10 bg-hw-charcoal/95 backdrop-blur-sm border-b border-hw-surface px-4 py-4">
+        <div className="flex items-center gap-4 max-w-2xl mx-auto">
+          <Link
+            href="/"
+            className="p-2 -ml-2 text-gray-400 hover:text-white rounded-lg hover:bg-hw-surface transition-colors"
+          >
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <h1 className="text-xl font-bold text-white">Settings</h1>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-6 space-y-6">
+        {/* Account Section */}
+        <section>
+          <h2 className="text-[10px] uppercase tracking-wider text-gray-500 font-medium mb-3 px-1">
+            Account
+          </h2>
+          <div className="bg-hw-surface rounded-xl overflow-hidden divide-y divide-hw-charcoal">
+            {status === 'loading' ? (
+              <div className="p-4 animate-pulse">
+                <div className="h-10 bg-gray-700 rounded" />
+              </div>
+            ) : isAuthenticated && session?.user ? (
+              <>
+                <Link
+                  href="/settings/account"
+                  className="flex items-center gap-4 p-4 hover:bg-hw-charcoal/50 transition-colors"
+                >
+                  <div className="w-12 h-12 rounded-full bg-hw-brass flex items-center justify-center shadow-knob">
+                    {session.user.image ? (
+                      <img
+                        src={session.user.image}
+                        alt={session.user.name || 'User'}
+                        className="w-12 h-12 rounded-full"
+                      />
+                    ) : (
+                      <span className="text-hw-charcoal font-bold text-lg">
+                        {(session.user.name || session.user.email || 'U')[0].toUpperCase()}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-white truncate">
+                      {session.user.name || 'User'}
+                    </p>
+                    <p className="text-sm text-gray-400 truncate">
+                      {session.user.email}
+                    </p>
+                  </div>
+                  <ChevronRight className="w-5 h-5 text-gray-500" />
+                </Link>
+
+                <button
+                  onClick={handleSignOut}
+                  className="flex items-center gap-4 p-4 w-full text-left hover:bg-hw-charcoal/50 transition-colors"
+                >
+                  <div className="w-10 h-10 rounded-lg bg-hw-charcoal flex items-center justify-center">
+                    <LogOut className="w-5 h-5 text-gray-400" />
+                  </div>
+                  <span className="text-gray-300">Sign out</span>
+                </button>
+              </>
+            ) : (
+              <Link
+                href="/auth/login?callbackUrl=/settings"
+                className="flex items-center gap-4 p-4 hover:bg-hw-charcoal/50 transition-colors"
+              >
+                <div className="w-10 h-10 rounded-lg bg-hw-brass/20 flex items-center justify-center">
+                  <User className="w-5 h-5 text-hw-brass" />
+                </div>
+                <div className="flex-1">
+                  <p className="font-medium text-white">Sign in</p>
+                  <p className="text-sm text-gray-400">
+                    Sync your data across devices
+                  </p>
+                </div>
+                <ChevronRight className="w-5 h-5 text-gray-500" />
+              </Link>
+            )}
+          </div>
+        </section>
+
+        {/* Sync Section */}
+        <section>
+          <h2 className="text-[10px] uppercase tracking-wider text-gray-500 font-medium mb-3 px-1">
+            Data
+          </h2>
+          <div className="bg-hw-surface rounded-xl overflow-hidden divide-y divide-hw-charcoal">
+            <button
+              onClick={sync}
+              disabled={!isAuthenticated || syncStatus === 'syncing'}
+              className="flex items-center gap-4 p-4 w-full text-left hover:bg-hw-charcoal/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <div className="w-10 h-10 rounded-lg bg-hw-charcoal flex items-center justify-center">
+                <Cloud
+                  className={`w-5 h-5 ${
+                    syncStatus === 'syncing'
+                      ? 'text-hw-brass animate-pulse'
+                      : 'text-gray-400'
+                  }`}
+                />
+              </div>
+              <div className="flex-1">
+                <p className="font-medium text-white">
+                  {syncStatus === 'syncing' ? 'Syncing...' : 'Sync now'}
+                </p>
+                <p className="text-sm text-gray-400">
+                  {!isAuthenticated
+                    ? 'Sign in to sync'
+                    : lastSyncedAt
+                    ? `Last synced: ${new Date(lastSyncedAt).toLocaleString()}`
+                    : 'Not synced yet'}
+                </p>
+              </div>
+            </button>
+
+            <button
+              onClick={handleClearData}
+              className="flex items-center gap-4 p-4 w-full text-left hover:bg-hw-charcoal/50 transition-colors"
+            >
+              <div className="w-10 h-10 rounded-lg bg-hw-red/10 flex items-center justify-center">
+                <Trash2 className="w-5 h-5 text-hw-red" />
+              </div>
+              <div className="flex-1">
+                <p className="font-medium text-hw-red">Clear local data</p>
+                <p className="text-sm text-gray-400">
+                  Remove all songs and practice history from this device
+                </p>
+              </div>
+            </button>
+          </div>
+        </section>
+
+        {/* Preferences Section */}
+        <section>
+          <h2 className="text-[10px] uppercase tracking-wider text-gray-500 font-medium mb-3 px-1">
+            Preferences
+          </h2>
+          <div className="bg-hw-surface rounded-xl overflow-hidden divide-y divide-hw-charcoal">
+            <Link
+              href="/settings/notifications"
+              className="flex items-center gap-4 p-4 hover:bg-hw-charcoal/50 transition-colors"
+            >
+              <div className="w-10 h-10 rounded-lg bg-hw-charcoal flex items-center justify-center">
+                <Bell className="w-5 h-5 text-gray-400" />
+              </div>
+              <div className="flex-1">
+                <p className="font-medium text-white">Notifications</p>
+                <p className="text-sm text-gray-400">Practice reminders</p>
+              </div>
+              <ChevronRight className="w-5 h-5 text-gray-500" />
+            </Link>
+
+            <Link
+              href="/settings/appearance"
+              className="flex items-center gap-4 p-4 hover:bg-hw-charcoal/50 transition-colors"
+            >
+              <div className="w-10 h-10 rounded-lg bg-hw-charcoal flex items-center justify-center">
+                <Palette className="w-5 h-5 text-gray-400" />
+              </div>
+              <div className="flex-1">
+                <p className="font-medium text-white">Appearance</p>
+                <p className="text-sm text-gray-400">Theme and display</p>
+              </div>
+              <ChevronRight className="w-5 h-5 text-gray-500" />
+            </Link>
+          </div>
+        </section>
+
+        {/* About Section */}
+        <section>
+          <h2 className="text-[10px] uppercase tracking-wider text-gray-500 font-medium mb-3 px-1">
+            About
+          </h2>
+          <div className="bg-hw-surface rounded-xl overflow-hidden divide-y divide-hw-charcoal">
+            <Link
+              href="/settings/help"
+              className="flex items-center gap-4 p-4 hover:bg-hw-charcoal/50 transition-colors"
+            >
+              <div className="w-10 h-10 rounded-lg bg-hw-charcoal flex items-center justify-center">
+                <HelpCircle className="w-5 h-5 text-gray-400" />
+              </div>
+              <div className="flex-1">
+                <p className="font-medium text-white">Help & Feedback</p>
+              </div>
+              <ChevronRight className="w-5 h-5 text-gray-500" />
+            </Link>
+          </div>
+
+          <p className="text-center text-gray-500 text-xs mt-4">
+            MetMap v1.0.0 - Part of Flux Studio
+          </p>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/metmap/src/components/SyncButton.tsx
+++ b/metmap/src/components/SyncButton.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { Cloud, CloudOff, RefreshCw, Check, AlertCircle } from 'lucide-react';
+import { useSync } from '@/hooks/useSync';
+import Link from 'next/link';
+
+interface SyncButtonProps {
+  compact?: boolean;
+}
+
+export function SyncButton({ compact = false }: SyncButtonProps) {
+  const { sync, syncStatus, isAuthenticated, isLoading, error } = useSync();
+
+  // Show loading state while checking auth
+  if (isLoading) {
+    return (
+      <div className={`flex items-center gap-2 ${compact ? 'text-sm' : ''}`}>
+        <RefreshCw className="w-4 h-4 animate-spin text-gray-500" />
+      </div>
+    );
+  }
+
+  // Show sign-in prompt if not authenticated
+  if (!isAuthenticated) {
+    return (
+      <Link
+        href="/auth/login"
+        className={`flex items-center gap-2 px-3 py-2 rounded-lg bg-hw-surface hover:bg-hw-surface/80 transition-colors ${
+          compact ? 'text-sm' : ''
+        }`}
+        title="Sign in to sync your data"
+      >
+        <CloudOff className="w-4 h-4 text-gray-500" />
+        {!compact && <span className="text-gray-400">Sign in to sync</span>}
+      </Link>
+    );
+  }
+
+  // Syncing state
+  if (syncStatus === 'syncing') {
+    return (
+      <button
+        disabled
+        className={`flex items-center gap-2 px-3 py-2 rounded-lg bg-hw-surface cursor-wait ${
+          compact ? 'text-sm' : ''
+        }`}
+      >
+        <RefreshCw className="w-4 h-4 animate-spin text-hw-brass" />
+        {!compact && <span className="text-gray-400">Syncing...</span>}
+      </button>
+    );
+  }
+
+  // Error state
+  if (syncStatus === 'error') {
+    return (
+      <button
+        onClick={sync}
+        className={`flex items-center gap-2 px-3 py-2 rounded-lg bg-hw-red/10 hover:bg-hw-red/20 transition-colors ${
+          compact ? 'text-sm' : ''
+        }`}
+        title={error || 'Sync failed. Click to retry.'}
+      >
+        <AlertCircle className="w-4 h-4 text-hw-red" />
+        {!compact && <span className="text-hw-red">Retry sync</span>}
+      </button>
+    );
+  }
+
+  // Success state (show briefly then return to idle)
+  if (syncStatus === 'success') {
+    return (
+      <button
+        onClick={sync}
+        className={`flex items-center gap-2 px-3 py-2 rounded-lg bg-green-500/10 hover:bg-green-500/20 transition-colors ${
+          compact ? 'text-sm' : ''
+        }`}
+      >
+        <Check className="w-4 h-4 text-green-500" />
+        {!compact && <span className="text-green-500">Synced</span>}
+      </button>
+    );
+  }
+
+  // Idle state - ready to sync
+  return (
+    <button
+      onClick={sync}
+      className={`flex items-center gap-2 px-3 py-2 rounded-lg bg-hw-surface hover:bg-hw-brass/20 transition-colors ${
+        compact ? 'text-sm' : ''
+      }`}
+      title="Sync your data to the cloud"
+    >
+      <Cloud className="w-4 h-4 text-hw-brass" />
+      {!compact && <span className="text-gray-300">Sync</span>}
+    </button>
+  );
+}
+
+/**
+ * Compact sync indicator for headers/nav
+ */
+export function SyncIndicator() {
+  return <SyncButton compact />;
+}

--- a/metmap/src/components/auth/LoginForm.tsx
+++ b/metmap/src/components/auth/LoginForm.tsx
@@ -52,7 +52,7 @@ export function LoginForm() {
 
         <div className="p-8">
           <h1 className="text-2xl font-bold text-white mb-2">Welcome back</h1>
-          <p className="text-gray-400 mb-6">Sign in to sync your practice data</p>
+          <p className="text-gray-400 mb-6">Sign in to access your saved songs</p>
 
           {errorMessage && (
             <div className="mb-4 p-3 bg-hw-red/10 border border-hw-red/20 rounded-lg text-hw-red text-sm">

--- a/metmap/src/components/auth/SignupForm.tsx
+++ b/metmap/src/components/auth/SignupForm.tsx
@@ -93,7 +93,7 @@ export function SignupForm() {
 
         <div className="p-8">
           <h1 className="text-2xl font-bold text-white mb-2">Create your account</h1>
-          <p className="text-gray-400 mb-6">Start syncing your practice across devices</p>
+          <p className="text-gray-400 mb-6">Save your songs and track your progress</p>
 
           {errorMessage && (
             <div className="mb-4 p-3 bg-hw-red/10 border border-hw-red/20 rounded-lg text-hw-red text-sm">

--- a/metmap/src/hooks/useSync.ts
+++ b/metmap/src/hooks/useSync.ts
@@ -1,0 +1,156 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useState, useCallback } from 'react';
+import { useMetMapStore } from '@/stores/useMetMapStore';
+
+export type SyncStatus = 'idle' | 'syncing' | 'success' | 'error';
+
+interface SyncResult {
+  success: boolean;
+  message?: string;
+  syncedAt?: string;
+}
+
+/**
+ * Hook for syncing localStorage data with the server
+ */
+export function useSync() {
+  const { data: session, status: authStatus } = useSession();
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle');
+  const [lastSyncedAt, setLastSyncedAt] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const songs = useMetMapStore((state) => state.songs);
+  const sessions = useMetMapStore((state) => state.sessions);
+
+  const isAuthenticated = authStatus === 'authenticated' && !!session?.user;
+
+  /**
+   * Sync local data to the server
+   */
+  const sync = useCallback(async (): Promise<SyncResult> => {
+    if (!isAuthenticated) {
+      return {
+        success: false,
+        message: 'You must be signed in to sync',
+      };
+    }
+
+    setSyncStatus('syncing');
+    setError(null);
+
+    try {
+      const response = await fetch('/api/sync', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          songs,
+          sessions,
+          lastSyncedAt,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Sync failed');
+      }
+
+      const result = await response.json();
+
+      setSyncStatus('success');
+      setLastSyncedAt(result.syncedAt);
+
+      // Update the local store with the synced data
+      // This merges server data back into localStorage
+      const store = useMetMapStore.getState();
+
+      // Replace local data with server data
+      // The server has the authoritative merged version
+      if (result.data?.songs) {
+        // Clear and replace songs
+        store.clearAllData();
+        for (const song of result.data.songs) {
+          store.importSong(song);
+        }
+      }
+
+      return {
+        success: true,
+        syncedAt: result.syncedAt,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setSyncStatus('error');
+      setError(message);
+      return {
+        success: false,
+        message,
+      };
+    }
+  }, [isAuthenticated, songs, sessions, lastSyncedAt]);
+
+  /**
+   * Pull data from server (download only, no upload)
+   */
+  const pull = useCallback(async (): Promise<SyncResult> => {
+    if (!isAuthenticated) {
+      return {
+        success: false,
+        message: 'You must be signed in to sync',
+      };
+    }
+
+    setSyncStatus('syncing');
+    setError(null);
+
+    try {
+      const response = await fetch('/api/sync');
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Failed to fetch data');
+      }
+
+      const result = await response.json();
+
+      // Update the local store with server data
+      const store = useMetMapStore.getState();
+
+      if (result.data?.songs) {
+        store.clearAllData();
+        for (const song of result.data.songs) {
+          store.importSong(song);
+        }
+      }
+
+      setSyncStatus('success');
+      setLastSyncedAt(new Date().toISOString());
+
+      return {
+        success: true,
+        syncedAt: new Date().toISOString(),
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setSyncStatus('error');
+      setError(message);
+      return {
+        success: false,
+        message,
+      };
+    }
+  }, [isAuthenticated]);
+
+  return {
+    sync,
+    pull,
+    syncStatus,
+    lastSyncedAt,
+    error,
+    isAuthenticated,
+    isLoading: authStatus === 'loading',
+  };
+}


### PR DESCRIPTION
- Add API routes for songs CRUD operations (/api/songs)
- Add API routes for sections CRUD operations (/api/songs/[id]/sections)
- Add API routes for practice sessions (/api/sessions)
- Add sync endpoint for localStorage to database sync (/api/sync)
- Add SyncButton component with status indicators
- Add useSync hook for client-side sync operations
- Add Settings page with account, sync, and preferences sections
- Add Account management page with user profile
- Fix false sync promises in UI text (signup, login, welcome pages)
- Apply hardware aesthetic to welcome page
- Add settings link to home page header