### PR TITLE
feat(metmap): Use bars/counts instead of time for sections

### DIFF
--- a/metmap/src/app/page.tsx
+++ b/metmap/src/app/page.tsx
@@ -196,33 +196,32 @@ function SongCard({ song }: { song: ReturnType<typeof useSongsByLastPracticed>[n
         </button>
       </div>
 
-      {/* Section preview bar */}
-      {song.sections.length > 0 && song.duration > 0 && (
-        <div className="mt-3 h-2 bg-hw-charcoal rounded-full overflow-hidden flex">
-          {song.sections.map((section) => {
-            const width = ((section.endTime - section.startTime) / song.duration) * 100;
-            const left = (section.startTime / song.duration) * 100;
-            return (
-              <div
-                key={section.id}
-                className={clsx(
-                  'h-full',
-                  section.confidence === 1 && 'bg-red-500',
-                  section.confidence === 2 && 'bg-orange-500',
-                  section.confidence === 3 && 'bg-yellow-500',
-                  section.confidence === 4 && 'bg-lime-500',
-                  section.confidence === 5 && 'bg-green-500'
-                )}
-                style={{
-                  width: `${width}%`,
-                  marginLeft: section === song.sections[0] ? `${left}%` : undefined,
-                }}
-                title={`${section.name}: ${section.confidence}/5`}
-              />
-            );
-          })}
-        </div>
-      )}
+      {/* Section preview bar - shows sections proportionally based on bar counts */}
+      {song.sections.length > 0 && (() => {
+        const totalBars = song.sections.reduce((sum, s) => sum + (s.bars || 8), 0);
+        return (
+          <div className="mt-3 h-2 bg-hw-charcoal rounded-full overflow-hidden flex">
+            {song.sections.map((section) => {
+              const width = ((section.bars || 8) / totalBars) * 100;
+              return (
+                <div
+                  key={section.id}
+                  className={clsx(
+                    'h-full',
+                    section.confidence === 1 && 'bg-red-500',
+                    section.confidence === 2 && 'bg-orange-500',
+                    section.confidence === 3 && 'bg-yellow-500',
+                    section.confidence === 4 && 'bg-lime-500',
+                    section.confidence === 5 && 'bg-green-500'
+                  )}
+                  style={{ width: `${width}%` }}
+                  title={`${section.name}: ${section.bars || 8} bars, ${section.confidence}/5`}
+                />
+              );
+            })}
+          </div>
+        );
+      })()}
     </Link>
   );
 }

--- a/metmap/src/app/song/[id]/practice/page.tsx
+++ b/metmap/src/app/song/[id]/practice/page.tsx
@@ -84,24 +84,26 @@ export default function PracticeModePage() {
   useEffect(() => {
     if (!isPaused && song && song.sections.length > 0) {
       const section = song.sections[currentSectionIndex];
+      const sectionEndTime = section.endTime ?? 0;
+      const sectionStartTime = section.startTime ?? 0;
 
       timerRef.current = setInterval(() => {
         setCurrentTime((time) => {
           const newTime = time + 0.1;
 
           // Check if we've reached the end of the section
-          if (newTime >= section.endTime) {
+          if (sectionEndTime > 0 && newTime >= sectionEndTime) {
             if (isLooping) {
               // Loop back to start of section
-              return section.startTime;
+              return sectionStartTime;
             } else {
               // Move to next section or pause
               if (currentSectionIndex < song.sections.length - 1) {
                 setCurrentSectionIndex((i) => i + 1);
-                return song.sections[currentSectionIndex + 1].startTime;
+                return song.sections[currentSectionIndex + 1].startTime ?? 0;
               } else {
                 setIsPaused(true);
-                return section.endTime;
+                return sectionEndTime;
               }
             }
           }
@@ -121,7 +123,7 @@ export default function PracticeModePage() {
   // Jump to section start when section changes
   useEffect(() => {
     if (song && song.sections.length > 0) {
-      setCurrentTime(song.sections[currentSectionIndex].startTime);
+      setCurrentTime(song.sections[currentSectionIndex].startTime ?? 0);
     }
   }, [currentSectionIndex, song]);
 
@@ -172,10 +174,12 @@ export default function PracticeModePage() {
 
   const currentSection = song.sections[currentSectionIndex];
   const weakSections = getSectionsNeedingPractice(song);
-  const sectionProgress =
-    ((currentTime - currentSection.startTime) /
-      (currentSection.endTime - currentSection.startTime)) *
-    100;
+  const startTime = currentSection.startTime ?? 0;
+  const endTime = currentSection.endTime ?? 0;
+  const sectionDuration = endTime - startTime;
+  const sectionProgress = sectionDuration > 0
+    ? ((currentTime - startTime) / sectionDuration) * 100
+    : 0;
 
   return (
     <main className="flex-1 flex flex-col bg-hw-charcoal text-white">
@@ -216,10 +220,10 @@ export default function PracticeModePage() {
           </div>
         </div>
 
-        {/* Section name and time */}
+        {/* Section name and bars */}
         <h2 className="text-2xl font-bold mb-2">{currentSection.name}</h2>
         <p className="text-gray-400 mb-6">
-          {formatTime(currentSection.startTime)} - {formatTime(currentSection.endTime)}
+          {currentSection.bars || 8} bars
         </p>
 
         {/* Progress bar */}
@@ -232,7 +236,7 @@ export default function PracticeModePage() {
           </div>
           <div className="flex justify-between text-xs text-gray-500 mt-1">
             <span>{formatTime(currentTime)}</span>
-            <span>{formatTime(currentSection.endTime)}</span>
+            <span>{formatTime(endTime)}</span>
           </div>
         </div>
 

--- a/metmap/src/stores/useMetMapStore.ts
+++ b/metmap/src/stores/useMetMapStore.ts
@@ -28,7 +28,7 @@ interface MetMapActions {
   // Section actions
   addSection: (
     songId: string,
-    section: Partial<Section> & Pick<Section, 'name' | 'startTime' | 'endTime'>
+    section: Partial<Section> & Pick<Section, 'name' | 'bars'>
   ) => Section | undefined;
   updateSection: (songId: string, sectionId: string, updates: Partial<Section>) => void;
   deleteSection: (songId: string, sectionId: string) => void;
@@ -103,13 +103,10 @@ export const useMetMapStore = create<MetMapStore>()(
           songs: state.songs.map((song) => {
             if (song.id === songId) {
               addedSection = section;
-              // Insert section in order by startTime
-              const sections = [...song.sections, section].sort(
-                (a, b) => a.startTime - b.startTime
-              );
+              // Add section to the end of the list
               return {
                 ...song,
-                sections,
+                sections: [...song.sections, section],
                 updatedAt: new Date().toISOString(),
               };
             }

--- a/metmap/src/types/metmap.ts
+++ b/metmap/src/types/metmap.ts
@@ -25,7 +25,7 @@ export type ConfidenceLevel = 1 | 2 | 3 | 4 | 5;
 
 /**
  * A Section represents a discrete part of a song to practice.
- * Sections have timestamps, labels, and can track practice progress.
+ * Sections have bar counts, labels, and can track practice progress.
  */
 export interface Section {
   id: ID;
@@ -33,10 +33,8 @@ export interface Section {
   name: string;
   /** Section type for categorization and color-coding */
   type: SectionType;
-  /** Start time in seconds */
-  startTime: number;
-  /** End time in seconds */
-  endTime: number;
+  /** Number of bars/counts in this section */
+  bars: number;
   /** Optional notes about this section (techniques, challenges, etc.) */
   notes?: string;
   /** Current confidence level (1-5) */
@@ -47,6 +45,11 @@ export interface Section {
   lastPracticed?: string;
   /** Color override (defaults based on type) */
   color?: string;
+  // Legacy fields for backwards compatibility
+  /** @deprecated Use bars instead */
+  startTime?: number;
+  /** @deprecated Use bars instead */
+  endTime?: number;
 }
 
 /**
@@ -191,12 +194,12 @@ export function createSong(partial: Partial<Song> & Pick<Song, 'title' | 'artist
  * Create a new section with defaults
  */
 export function createSection(
-  partial: Partial<Section> & Pick<Section, 'name' | 'startTime' | 'endTime'>
+  partial: Partial<Section> & Pick<Section, 'name' | 'bars'>
 ): Section {
   return {
     id: generateId(),
     type: 'custom',
-    confidence: 1,
+    confidence: 3,
     practiceCount: 0,
     ...partial,
   };


### PR DESCRIPTION
Changed section model from time-based (startTime/endTime) to bar-based:
- Section interface now uses 'bars' field (with legacy time fields optional)
- AddSectionModal accepts bar count input instead of start/end times
- SectionCard displays and allows editing of bar count
- Timeline visualizations show sections proportionally by bar count
- Practice mode updated to handle optional time fields gracefully