### PR TITLE
feat(metmap): Integrate ChordTimeline into song section cards

### DIFF
--- a/metmap/src/types/metmap.ts
+++ b/metmap/src/types/metmap.ts
@@ -5,6 +5,8 @@
  * All data is persisted to localStorage for offline-first mobile use.
  */
 
+import type { ChordEvent } from './song';
+
 /** Unique identifier type */
 export type ID = string;
 
@@ -45,6 +47,8 @@ export interface Section {
   lastPracticed?: string;
   /** Color override (defaults based on type) */
   color?: string;
+  /** Chord progression for this section */
+  chords?: ChordEvent[];
   // Legacy fields for backwards compatibility
   /** @deprecated Use bars instead */
   startTime?: number;


### PR DESCRIPTION
- Add chords field to Section type in metmap.ts (imports ChordEvent from song.ts)
- Update SectionCard with expandable ChordTimeline panel
- Click chevron to expand/collapse chord progression editor
- Chord changes persist via updateSection to Zustand store
- Shows chord count badge when section has chords
- Displays time signature from song settings