### PR TITLE
Update FluxStudio.art login and database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # FluxStudio Environment Configuration
 
-# Database Configuration
+# Database Configuration (MetMap-compatible)
+# Use DATABASE_URL for production (DigitalOcean managed PostgreSQL)
+# This is the same database used by MetMap for unified authentication
+DATABASE_URL=postgresql://user:password@host:port/database?sslmode=require
+USE_DATABASE=true
+
+# Legacy individual database config (fallback for local development)
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=fluxstudio

--- a/database/auth-adapter.js
+++ b/database/auth-adapter.js
@@ -93,22 +93,27 @@ class AuthAdapter {
   }
 
   // Transform database user to frontend format
+  // Supports both FluxStudio schema (password_hash) and MetMap schema (passwordHash mapped to password_hash)
   transformUser(dbUser) {
     return {
       id: dbUser.id,
       email: dbUser.email,
       name: dbUser.name,
-      userType: dbUser.user_type,
+      // Include password hash for authentication (used by server-unified.js)
+      password: dbUser.password_hash || dbUser.passwordHash,
+      passwordHash: dbUser.password_hash || dbUser.passwordHash,
+      userType: dbUser.user_type || 'client',
       googleId: dbUser.oauth_id,
-      avatar_url: dbUser.avatar_url,
+      avatar_url: dbUser.avatar_url || dbUser.image,
+      image: dbUser.image || dbUser.avatar_url,
       phone: dbUser.phone,
       timezone: dbUser.timezone,
       preferences: dbUser.preferences,
-      emailVerified: dbUser.email_verified,
-      isActive: dbUser.is_active,
+      emailVerified: dbUser.email_verified || dbUser.emailVerified,
+      isActive: dbUser.is_active !== false,
       lastLogin: dbUser.last_login,
-      createdAt: dbUser.created_at,
-      updatedAt: dbUser.updated_at
+      createdAt: dbUser.created_at || dbUser.createdAt,
+      updatedAt: dbUser.updated_at || dbUser.updatedAt
     };
   }
 

--- a/lib/auth/authHelpers.js
+++ b/lib/auth/authHelpers.js
@@ -28,8 +28,8 @@ async function generateAuthResponse(user, req) {
   // Generate token pair (access + refresh)
   const tokens = await tokenService.generateTokenPair(user, deviceInfo);
 
-  // Return user data without sensitive fields
-  const { password, googleId, ...userWithoutPassword } = user;
+  // Return user data without sensitive fields (FluxStudio and MetMap compatible)
+  const { password, passwordHash, googleId, ...userWithoutPassword } = user;
 
   return {
     // Legacy field for backward compatibility (access token)

--- a/server-unified.js
+++ b/server-unified.js
@@ -823,7 +823,8 @@ app.get('/auth/me', authenticateToken, async (req, res) => {
     return res.status(404).json({ message: 'User not found' });
   }
 
-  const { password: _, ...userWithoutPassword } = user;
+  // Remove both password fields (FluxStudio and MetMap compatible)
+  const { password: _p, passwordHash: _ph, ...userWithoutPassword } = user;
   res.json(userWithoutPassword);
 });
 


### PR DESCRIPTION
- Update auth-adapter.js to support both FluxStudio and MetMap user schemas
- Add password/passwordHash fields for authentication compatibility
- Update .env.example to use DATABASE_URL format (MetMap-compatible)
- Ensure password fields are stripped from all API responses
- Add USE_DATABASE flag for production database configuration

This enables FluxStudio.art to share the same authentication database with MetMap for unified user accounts across both applications.