### PR TITLE
fix(deploy): Add catchall_document for SPA routing

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -59,6 +59,7 @@ static_sites:
     build_command: npm ci && npm run build
     output_dir: build
     environment_slug: node-js
+    catchall_document: index.html
     envs:
       - key: VITE_API_BASE_URL
         value: /api


### PR DESCRIPTION
Without this setting, DigitalOcean App Platform returns 404 for client-side routes like /login. The catchall_document ensures index.html is served for all routes, allowing React Router to handle navigation properly.