### PR TITLE
feat(metmap): Unify logo colors across all components

### DIFF
--- a/metmap/src/components/MetMapLogo.tsx
+++ b/metmap/src/components/MetMapLogo.tsx
@@ -7,6 +7,12 @@ interface MetMapLogoProps {
   size?: 'sm' | 'md' | 'lg';
 }
 
+// Logo colors - Cyan with Pink chromatic aberration
+const logoColors = {
+  cyan: '#4CC9F0',
+  pink: '#FF4DA6',
+};
+
 /**
  * MetMap logo - stylized "M" waveform with chromatic aberration effect
  */
@@ -24,33 +30,22 @@ export function MetMapLogo({ className = '', size = 'md' }: MetMapLogoProps) {
         fill="none"
         className="w-full h-full"
       >
-        {/* Pink/Magenta offset layer (chromatic aberration) */}
+        {/* Pink chromatic offset layer (back) */}
         <path
           d="M 80 340 L 120 180 L 180 320 L 250 100 L 320 320 L 380 200 L 400 280 Q 420 340 380 360 L 360 340"
-          stroke="#FF69B4"
-          strokeWidth="28"
+          stroke={logoColors.pink}
+          strokeWidth="26"
           strokeLinecap="round"
           strokeLinejoin="round"
-          transform="translate(-3, -3)"
+          transform="translate(4, 4)"
           opacity="0.7"
         />
 
-        {/* Cyan offset layer (chromatic aberration) */}
+        {/* Cyan main stroke (front) */}
         <path
           d="M 80 340 L 120 180 L 180 320 L 250 100 L 320 320 L 380 200 L 400 280 Q 420 340 380 360 L 360 340"
-          stroke="#00CED1"
-          strokeWidth="28"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          transform="translate(3, 3)"
-          opacity="0.7"
-        />
-
-        {/* Main cyan/blue stroke */}
-        <path
-          d="M 80 340 L 120 180 L 180 320 L 250 100 L 320 320 L 380 200 L 400 280 Q 420 340 380 360 L 360 340"
-          stroke="#00BFFF"
-          strokeWidth="24"
+          stroke={logoColors.cyan}
+          strokeWidth="22"
           strokeLinecap="round"
           strokeLinejoin="round"
         />

--- a/metmap/src/styles/tokens/brand.ts
+++ b/metmap/src/styles/tokens/brand.ts
@@ -12,6 +12,10 @@ export const brand = {
     coral: "#FF5A70",
     white: "#F3F5FA",
 
+    // Logo colors (cyan with pink chromatic aberration)
+    logoCyan: "#4CC9F0",
+    logoPink: "#FF4DA6",
+
     // Chord type colors
     chordMajor: "#FFC857",
     chordMinor: "#4CC9F0",


### PR DESCRIPTION
- Update MetMapLogo component to use cyan/pink color scheme
- Add logoCyan and logoPink to brand tokens for consistency