### PR TITLE
feat(deploy): Add USE_DATABASE=true to enable shared accounts with Me…

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -128,10 +128,12 @@ services:
       - key: PORT
         value: "3001"
 
-      # Database (Existing PostgreSQL database)
+      # Database (Existing PostgreSQL database - same as MetMap for shared accounts)
       - key: DATABASE_URL
         scope: RUN_TIME
         type: SECRET
+      - key: USE_DATABASE
+        value: "true"
       - key: DB_SSL
         value: "true"
 


### PR DESCRIPTION
…tMap

FluxStudio unified-backend now explicitly enables database mode for authentication, allowing it to share user accounts with MetMap when both apps point to the same DATABASE_URL.