### PR TITLE
fix(oauth): Use plaintext GOOGLE_CLIENT_ID for backend

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -159,10 +159,10 @@ services:
         scope: RUN_TIME
         type: SECRET
 
-      # Google OAuth (MUST BE SET AS SECRETS)
+      # Google OAuth
+      # Note: Client ID is public (same as frontend), but secret must be set in DO dashboard
       - key: GOOGLE_CLIENT_ID
-        scope: RUN_TIME
-        type: SECRET
+        value: 65518208813-f4rgudom5b57qad0jlhjtsocsrb26mfc.apps.googleusercontent.com
       - key: GOOGLE_CLIENT_SECRET
         scope: RUN_TIME
         type: SECRET


### PR DESCRIPTION
The Google Client ID is public (same value used in frontend) and should not be configured as a secret. This fixes the 500 error on /api/auth/google endpoint by ensuring the client ID is always available at runtime.

GOOGLE_CLIENT_SECRET remains as a secret that must be set in the DigitalOcean App Platform dashboard.