### PR TITLE
fix(auth): Generate cuid IDs for MetMap database schema compatibility

### DIFF
--- a/database/auth-adapter.js
+++ b/database/auth-adapter.js
@@ -3,7 +3,7 @@
  * Provides database operations for the auth service
  */
 
-const { userQueries, organizationQueries, query } = require('./config');
+const { userQueries, organizationQueries, query, generateCuid } = require('./config');
 
 class AuthAdapter {
 
@@ -133,10 +133,11 @@ class AuthAdapter {
       const orgId = result.rows[0].id;
 
       // Add user as organization owner
+      const memberId = generateCuid();
       await query(
-        `INSERT INTO organization_members (organization_id, user_id, role, is_active)
-         VALUES ($1, $2, 'owner', true)`,
-        [orgId, userId]
+        `INSERT INTO organization_members (id, organization_id, user_id, role, is_active)
+         VALUES ($1, $2, $3, 'owner', true)`,
+        [memberId, orgId, userId]
       );
 
       return orgId;


### PR DESCRIPTION
MetMap uses Prisma with cuid() IDs which are generated by the application, not auto-incremented by PostgreSQL. Added generateCuid() function and updated userQueries.create, organizationQueries.create, and organization member inserts to include generated IDs.

Fixes: null value in column "id" of relation "users" violates not-null constraint