### PR TITLE
fix(auth): Fix org schema and pass req to generateAuthResponse

### DIFF
--- a/database/config.js
+++ b/database/config.js
@@ -413,11 +413,10 @@ const organizationQueries = {
   findById: (id) => query('SELECT * FROM organizations WHERE id = $1', [id]),
   create: (orgData) => {
     const id = generateCuid();
-    const now = new Date();
     return query(
-      `INSERT INTO organizations (id, name, slug, description, type, created_by, "createdAt", "updatedAt")
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *`,
-      [id, orgData.name, orgData.slug, orgData.description, orgData.type, orgData.created_by, now, now]
+      `INSERT INTO organizations (id, name, slug, description, type, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+      [id, orgData.name, orgData.slug, orgData.description, orgData.type, orgData.created_by]
     );
   }
 };

--- a/server-unified.js
+++ b/server-unified.js
@@ -566,7 +566,7 @@ app.post('/auth/google', async (req, res) => {
 
     // Generate auth response
     const authResponse = USE_DATABASE && authAdapter
-      ? await generateAuthResponse(user)
+      ? await generateAuthResponse(user, req)
       : simpleAuthResponse(user);
 
     res.json(authResponse);


### PR DESCRIPTION
1. Removed createdAt/updatedAt from organizations INSERT - the organizations table doesn't have these camelCase columns
2. Pass req parameter to generateAuthResponse in Google OAuth flow to fix "Cannot read properties of undefined (reading 'headers')"