### PR TITLE
refactor(auth): Remove JWT-based refresh token fallback

### DIFF
--- a/lib/auth/tokenService.js
+++ b/lib/auth/tokenService.js
@@ -65,32 +65,7 @@ function generateAccessToken(user) {
 }
 
 /**
- * Generate JWT-based Refresh Token (fallback when database storage fails)
- *
- * @param {Object} user - User object
- * @returns {string} JWT refresh token
- */
-function generateJwtRefreshToken(user) {
-  return jwt.sign(
-    {
-      id: user.id,
-      email: user.email,
-      type: 'refresh',
-      iat: Math.floor(Date.now() / 1000)
-    },
-    JWT_SECRET,
-    {
-      expiresIn: '7d', // 7 days
-      algorithm: 'HS256'
-    }
-  );
-}
-
-/**
  * Generate Refresh Token (Long-lived, stored in database)
- *
- * Falls back to JWT-based refresh token if database storage fails
- * (e.g., due to UUID type mismatch with MetMap's cuid IDs)
  *
  * @param {Object} user - User object
  * @param {Object} deviceInfo - Device information
@@ -148,12 +123,6 @@ async function generateRefreshToken(user, deviceInfo = {}) {
 
     return token;
   } catch (error) {
-    // Check if this is a UUID type mismatch error (MetMap uses cuid IDs, not UUIDs)
-    if (error.message && error.message.includes('invalid input syntax for type uuid')) {
-      console.warn('Refresh token DB storage failed (UUID type mismatch) - using JWT-based refresh token');
-      // Fall back to JWT-based refresh token that doesn't require database storage
-      return generateJwtRefreshToken(user);
-    }
     console.error('Error generating refresh token:', error);
     throw new Error('Failed to generate refresh token');
   }
@@ -207,39 +176,10 @@ function verifyAccessToken(token) {
 }
 
 /**
- * Verify JWT-based Refresh Token (fallback tokens)
- *
- * @param {string} token - JWT refresh token
- * @returns {Object|null} Decoded token payload or null if invalid
- */
-function verifyJwtRefreshToken(token) {
-  try {
-    const decoded = jwt.verify(token, JWT_SECRET, {
-      algorithms: ['HS256']
-    });
-
-    // Ensure it's a refresh token
-    if (decoded.type !== 'refresh') {
-      return null;
-    }
-
-    // Return in a format compatible with database token data
-    return {
-      user_id: decoded.id,
-      email: decoded.email,
-      isJwtBased: true, // Flag to indicate this is a JWT-based token
-      last_used_at: new Date()
-    };
-  } catch (error) {
-    return null;
-  }
-}
-
-/**
  * Verify Refresh Token
  *
  * Checks:
- * 1. Token exists in database OR is a valid JWT refresh token
+ * 1. Token exists in database
  * 2. Token not expired
  * 3. Token not revoked
  * 4. Device fingerprint matches (if provided)
@@ -251,13 +191,6 @@ function verifyJwtRefreshToken(token) {
  * @returns {Promise<Object|null>} Token data or null if invalid
  */
 async function verifyRefreshToken(token, options = {}) {
-  // First, check if this is a JWT-based refresh token (fallback for MetMap users)
-  const jwtTokenData = verifyJwtRefreshToken(token);
-  if (jwtTokenData) {
-    console.log('Verified JWT-based refresh token for user:', jwtTokenData.user_id);
-    return jwtTokenData;
-  }
-
   try {
     const result = await query(
       `SELECT * FROM refresh_tokens
@@ -338,91 +271,65 @@ async function refreshAccessToken(refreshToken, deviceInfo = {}) {
     return null;
   }
 
-  // Get user data - handle both UUID and string IDs
-  let userResult;
-  try {
-    userResult = await query(
-      'SELECT id, email, user_type as "userType" FROM users WHERE id = $1',
-      [tokenData.user_id]
-    );
-  } catch (error) {
-    // If query fails (e.g., due to type mismatch), try text cast
-    if (error.message && error.message.includes('invalid input syntax')) {
-      userResult = await query(
-        'SELECT id, email, user_type as "userType" FROM users WHERE id::text = $1',
-        [tokenData.user_id]
-      );
-    } else {
-      throw error;
-    }
-  }
+  // Get user data
+  const userResult = await query(
+    'SELECT id, email, user_type as "userType" FROM users WHERE id = $1',
+    [tokenData.user_id]
+  );
 
   if (userResult.rows.length === 0) {
-    // User doesn't exist anymore - revoke token (only for DB-backed tokens)
-    if (!tokenData.isJwtBased) {
-      await revokeRefreshToken(refreshToken);
-    }
+    // User doesn't exist anymore - revoke token
+    await revokeRefreshToken(refreshToken);
     return null;
   }
 
   const user = userResult.rows[0];
 
+  // Check if user was active recently (within threshold)
+  const lastUsed = new Date(tokenData.last_used_at);
+  const now = new Date();
+  const timeSinceLastUse = now - lastUsed;
+
   let newRefreshToken;
-  let newTokenId = tokenData.id || 'jwt-based';
+  let newTokenId = tokenData.id;
 
-  // For JWT-based tokens, always issue a new JWT refresh token
-  if (tokenData.isJwtBased) {
-    newRefreshToken = generateJwtRefreshToken(user);
-  } else {
-    // Check if user was active recently (within threshold)
-    const lastUsed = new Date(tokenData.last_used_at);
-    const now = new Date();
-    const timeSinceLastUse = now - lastUsed;
+  if (timeSinceLastUse < ACTIVITY_EXTENSION_THRESHOLD) {
+    // User is actively using the app - extend existing refresh token
+    const newExpiresAt = new Date(Date.now() + REFRESH_TOKEN_EXPIRY);
 
-    if (timeSinceLastUse < ACTIVITY_EXTENSION_THRESHOLD) {
-      // User is actively using the app - extend existing refresh token
-      const newExpiresAt = new Date(Date.now() + REFRESH_TOKEN_EXPIRY);
-
-      await query(
-        'UPDATE refresh_tokens SET expires_at = $1, last_used_at = NOW() WHERE token = $2',
-        [newExpiresAt, refreshToken]
-      );
-
-      newRefreshToken = refreshToken; // Reuse existing token
-    } else {
-      // User was inactive - issue new refresh token and revoke old one
-      await revokeRefreshToken(refreshToken);
-      newRefreshToken = await generateRefreshToken(user, deviceInfo);
-
-      // Get the new token ID
-      const newTokenResult = await query(
-        'SELECT id FROM refresh_tokens WHERE token = $1',
-        [newRefreshToken]
-      );
-      newTokenId = newTokenResult.rows[0]?.id || newTokenId;
-    }
-  }
-
-  // Log token refresh (skip for JWT-based tokens to avoid errors)
-  if (!tokenData.isJwtBased) {
-    const lastUsed = new Date(tokenData.last_used_at);
-    const now = new Date();
-    const timeSinceLastUse = now - lastUsed;
-
-    await securityLogger.logTokenRefreshed(
-      user.id,
-      tokenData.id,
-      newTokenId,
-      {
-        ip: deviceInfo.ipAddress,
-        headers: { 'user-agent': deviceInfo.userAgent }
-      },
-      {
-        activityExtended: timeSinceLastUse < ACTIVITY_EXTENSION_THRESHOLD,
-        timeSinceLastUse: Math.floor(timeSinceLastUse / 1000) // seconds
-      }
+    await query(
+      'UPDATE refresh_tokens SET expires_at = $1, last_used_at = NOW() WHERE token = $2',
+      [newExpiresAt, refreshToken]
     );
+
+    newRefreshToken = refreshToken; // Reuse existing token
+  } else {
+    // User was inactive - issue new refresh token and revoke old one
+    await revokeRefreshToken(refreshToken);
+    newRefreshToken = await generateRefreshToken(user, deviceInfo);
+
+    // Get the new token ID
+    const newTokenResult = await query(
+      'SELECT id FROM refresh_tokens WHERE token = $1',
+      [newRefreshToken]
+    );
+    newTokenId = newTokenResult.rows[0]?.id || newTokenId;
   }
+
+  // Log token refresh
+  await securityLogger.logTokenRefreshed(
+    user.id,
+    tokenData.id,
+    newTokenId,
+    {
+      ip: deviceInfo.ipAddress,
+      headers: { 'user-agent': deviceInfo.userAgent }
+    },
+    {
+      activityExtended: timeSinceLastUse < ACTIVITY_EXTENSION_THRESHOLD,
+      timeSinceLastUse: Math.floor(timeSinceLastUse / 1000) // seconds
+    }
+  );
 
   // Always generate new access token
   const accessToken = generateAccessToken(user);
@@ -432,7 +339,7 @@ async function refreshAccessToken(refreshToken, deviceInfo = {}) {
     refreshToken: newRefreshToken,
     expiresIn: 15 * 60, // 15 minutes
     tokenType: 'Bearer',
-    activityExtended: tokenData.isJwtBased ? false : (new Date() - new Date(tokenData.last_used_at)) < ACTIVITY_EXTENSION_THRESHOLD
+    activityExtended: timeSinceLastUse < ACTIVITY_EXTENSION_THRESHOLD
   };
 }
 


### PR DESCRIPTION
Database has been migrated to use TEXT for user_id columns, so the temporary JWT-based refresh token fallback is no longer needed.

Changes:
- Remove generateJwtRefreshToken() function
- Remove verifyJwtRefreshToken() function
- Simplify generateRefreshToken() to DB-only (no fallback)
- Simplify verifyRefreshToken() to DB-only (no JWT check)
- Simplify refreshAccessToken() (no isJwtBased handling)
- Remove all isJwtBased flags and UUID type cast fallbacks

Refresh tokens are now exclusively database-backed random strings.