### PR TITLE
fix(config): Disable Redis by default to prevent connection errors

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -138,6 +138,9 @@ services:
         value: "true"
 
       # Redis (Optional - for Socket.IO scaling)
+      # Disabled by default - enable when Redis database is added
+      - key: USE_REDIS
+        value: "false"
       - key: REDIS_URL
         scope: RUN_TIME
         type: SECRET


### PR DESCRIPTION
Add USE_REDIS=false since no Redis database is configured. This prevents the Redis reconnection spam in logs.