### PR TITLE
fix(db): Change refresh_tokens.user_id from UUID to TEXT for CUID sup…

### DIFF
--- a/database/init-production.sql
+++ b/database/init-production.sql
@@ -26,9 +26,10 @@ CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_users_oauth ON users(oauth_provider, oauth_id);
 
 -- Refresh Tokens table (Week 1 Security Sprint)
+-- Note: user_id is TEXT to support CUID format from MetMap integration
 CREATE TABLE IF NOT EXISTS refresh_tokens (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL,
   token_hash TEXT NOT NULL UNIQUE,
   device_fingerprint JSONB,
   ip_address INET,
@@ -45,12 +46,13 @@ CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token_hash ON refresh_tokens(token
 CREATE INDEX IF NOT EXISTS idx_refresh_tokens_expires_at ON refresh_tokens(expires_at);
 
 -- Security Events table (Week 2 Security Sprint)
+-- Note: user_id is TEXT to support CUID format from MetMap integration
 CREATE TABLE IF NOT EXISTS security_events (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   event_type VARCHAR(100) NOT NULL,
   severity VARCHAR(20) DEFAULT 'INFO',
-  user_id UUID REFERENCES users(id) ON DELETE SET NULL,
-  token_id UUID REFERENCES refresh_tokens(id) ON DELETE SET NULL,
+  user_id TEXT,
+  token_id UUID,
   ip_address INET,
   user_agent TEXT,
   metadata JSONB,

--- a/database/migrations/020_fix_user_id_uuid_to_text.sql
+++ b/database/migrations/020_fix_user_id_uuid_to_text.sql
@@ -1,0 +1,56 @@
+-- Migration: Fix user_id columns from UUID to TEXT
+-- Part of: Production Fix for Google OAuth
+-- Date: 2025-12-10
+-- Description: Change user_id columns from UUID to TEXT to support CUID user IDs
+-- This migration handles the case where init-production.sql created UUID columns
+-- but the application uses CUID-formatted user IDs (e.g., cmiz5x2v00trBtgvh9Io5kdWi)
+
+-- First, drop the foreign key constraint on refresh_tokens (if it exists)
+ALTER TABLE refresh_tokens DROP CONSTRAINT IF EXISTS refresh_tokens_user_id_fkey;
+ALTER TABLE refresh_tokens DROP CONSTRAINT IF EXISTS fk_user;
+ALTER TABLE refresh_tokens DROP CONSTRAINT IF EXISTS fk_refresh_tokens_user_id;
+
+-- Drop the foreign key constraint on security_events (if it exists)
+ALTER TABLE security_events DROP CONSTRAINT IF EXISTS security_events_user_id_fkey;
+ALTER TABLE security_events DROP CONSTRAINT IF EXISTS fk_security_events_user_id;
+
+-- Change refresh_tokens.user_id from UUID to TEXT
+-- Using a conditional approach to handle both UUID and VARCHAR types
+DO $$
+BEGIN
+  -- Check if the column is UUID type
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'refresh_tokens'
+    AND column_name = 'user_id'
+    AND data_type = 'uuid'
+  ) THEN
+    ALTER TABLE refresh_tokens ALTER COLUMN user_id TYPE TEXT USING user_id::TEXT;
+    RAISE NOTICE 'refresh_tokens.user_id converted from UUID to TEXT';
+  ELSE
+    RAISE NOTICE 'refresh_tokens.user_id is already TEXT or VARCHAR';
+  END IF;
+END $$;
+
+-- Change security_events.user_id from UUID to TEXT
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'security_events'
+    AND column_name = 'user_id'
+    AND data_type = 'uuid'
+  ) THEN
+    ALTER TABLE security_events ALTER COLUMN user_id TYPE TEXT USING user_id::TEXT;
+    RAISE NOTICE 'security_events.user_id converted from UUID to TEXT';
+  ELSE
+    RAISE NOTICE 'security_events.user_id is already TEXT or VARCHAR';
+  END IF;
+END $$;
+
+-- Drop the token_id FK constraint on security_events (if referencing refresh_tokens)
+ALTER TABLE security_events DROP CONSTRAINT IF EXISTS security_events_token_id_fkey;
+
+-- Update comments for documentation
+COMMENT ON COLUMN refresh_tokens.user_id IS 'User ID (TEXT to support CUID format from MetMap integration)';
+COMMENT ON COLUMN security_events.user_id IS 'User ID (TEXT to support CUID format from MetMap integration)';

--- a/lib/migrations/004_fix_user_id_uuid_to_text.sql
+++ b/lib/migrations/004_fix_user_id_uuid_to_text.sql
@@ -1,0 +1,56 @@
+-- Migration: Fix user_id columns from UUID to TEXT
+-- Part of: Production Fix
+-- Date: 2025-12-10
+-- Description: Change user_id columns from UUID to TEXT to support CUID user IDs
+-- This migration handles the case where init-production.sql created UUID columns
+-- but the application uses CUID-formatted user IDs
+
+-- First, drop the foreign key constraint on refresh_tokens (if it exists)
+ALTER TABLE refresh_tokens DROP CONSTRAINT IF EXISTS refresh_tokens_user_id_fkey;
+ALTER TABLE refresh_tokens DROP CONSTRAINT IF EXISTS fk_user;
+ALTER TABLE refresh_tokens DROP CONSTRAINT IF EXISTS fk_refresh_tokens_user_id;
+
+-- Drop the foreign key constraint on security_events (if it exists)
+ALTER TABLE security_events DROP CONSTRAINT IF EXISTS security_events_user_id_fkey;
+ALTER TABLE security_events DROP CONSTRAINT IF EXISTS fk_security_events_user_id;
+
+-- Change refresh_tokens.user_id from UUID to TEXT
+-- Using a conditional approach to handle both UUID and VARCHAR types
+DO $$
+BEGIN
+  -- Check if the column is UUID type
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'refresh_tokens'
+    AND column_name = 'user_id'
+    AND data_type = 'uuid'
+  ) THEN
+    ALTER TABLE refresh_tokens ALTER COLUMN user_id TYPE TEXT USING user_id::TEXT;
+    RAISE NOTICE 'refresh_tokens.user_id converted from UUID to TEXT';
+  ELSE
+    RAISE NOTICE 'refresh_tokens.user_id is already TEXT or VARCHAR';
+  END IF;
+END $$;
+
+-- Change security_events.user_id from UUID to TEXT
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'security_events'
+    AND column_name = 'user_id'
+    AND data_type = 'uuid'
+  ) THEN
+    ALTER TABLE security_events ALTER COLUMN user_id TYPE TEXT USING user_id::TEXT;
+    RAISE NOTICE 'security_events.user_id converted from UUID to TEXT';
+  ELSE
+    RAISE NOTICE 'security_events.user_id is already TEXT or VARCHAR';
+  END IF;
+END $$;
+
+-- Change security_events.token_id constraint reference type if needed
+ALTER TABLE security_events DROP CONSTRAINT IF EXISTS security_events_token_id_fkey;
+
+-- Update comments for documentation
+COMMENT ON COLUMN refresh_tokens.user_id IS 'User ID (TEXT to support CUID format from MetMap integration)';
+COMMENT ON COLUMN security_events.user_id IS 'User ID (TEXT to support CUID format from MetMap integration)';

--- a/server-unified.js
+++ b/server-unified.js
@@ -44,8 +44,8 @@ const { createMonitoringRouter } = require('./monitoring/endpoints');
 // Import Redis cache layer
 const cache = require('./lib/cache');
 
-// Import database query function (for Phase 1 webhook storage)
-const { query } = require('./database/config');
+// Import database query function (for Phase 1 webhook storage) and migrations
+const { query, runMigrations } = require('./database/config');
 
 // Import Week 1 Security Sprint - JWT Refresh Token Routes
 const refreshTokenRoutes = require('./lib/auth/refreshTokenRoutes');
@@ -4498,7 +4498,7 @@ app.use(errorHandler());
 // Security error handler (must be last)
 app.use(securityErrorHandler);
 
-httpServer.listen(PORT, () => {
+httpServer.listen(PORT, async () => {
   console.log('');
   console.log('='.repeat(60));
   console.log('🚀 FluxStudio Unified Backend Service');
@@ -4508,6 +4508,20 @@ httpServer.listen(PORT, () => {
   console.log(`💬 Messaging namespace: ws://localhost:${PORT}/messaging`);
   console.log(`🏥 Health check: http://localhost:${PORT}/health`);
   console.log(`📊 Monitoring: http://localhost:${PORT}/api/monitoring`);
+  console.log('');
+
+  // Run database migrations on startup (if using database)
+  if (USE_DATABASE) {
+    try {
+      console.log('🔄 Running database migrations...');
+      await runMigrations();
+      console.log('✅ Database migrations completed');
+    } catch (migrationError) {
+      console.error('⚠️ Migration warning:', migrationError.message);
+      // Don't crash server on migration errors - log and continue
+    }
+  }
+
   console.log('');
   console.log('Services consolidated:');
   console.log('  ✅ Authentication (formerly port 3001)');


### PR DESCRIPTION
…port

- Create migration 020_fix_user_id_uuid_to_text.sql to convert UUID columns
- Update init-production.sql to use TEXT for user_id columns
- Add migration run on server startup in server-unified.js
- Fix GitHubSyncService SSL config to strip sslmode from DATABASE_URL

This fixes Google OAuth login failing with "invalid input syntax for type uuid" error when user IDs are in CUID format (e.g., cmiz5x2v00trBtgvh9Io5kdWi) from the MetMap integration.