### PR TITLE
fix(db): Use createdAt (camelCase) to match MetMap/Prisma schema

### DIFF
--- a/database/auth-adapter.js
+++ b/database/auth-adapter.js
@@ -10,7 +10,8 @@ class AuthAdapter {
   // User management
   async getUsers() {
     try {
-      const result = await query('SELECT * FROM users WHERE is_active = true ORDER BY created_at DESC');
+      // Use "createdAt" (camelCase) to match MetMap/Prisma schema
+      const result = await query('SELECT * FROM users WHERE is_active = true ORDER BY "createdAt" DESC');
       return result.rows.map(this.transformUser);
     } catch (error) {
       console.error('Error getting users:', error);


### PR DESCRIPTION
The users table in the shared MetMap database uses camelCase column names from Prisma (createdAt) instead of snake_case (created_at).