### PR TITLE
refactor(tools): Integrate Tools page with standard DashboardLayout p…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import Settings from './pages/Settings';
 import { MessagesNew } from './pages/MessagesNew';
 import OAuthCallback from './pages/OAuthCallback';
 
-// Tools page - completely self-contained, no context dependencies
+// Tools page - uses DashboardLayout like other pages
 import Tools from './pages/Tools';
 
 // Lazy load non-critical pages and components
@@ -101,6 +101,7 @@ function AuthenticatedRoutes() {
                   <Route path="/profile" element={<Profile />} />
                   <Route path="/settings" element={<Settings />} />
                   <Route path="/connectors" element={<Connectors />} />
+                  <Route path="/tools" element={<Tools />} />
 
                   {/* Legacy routes for backward compatibility */}
                   <Route path="/organization/legacy" element={<OrganizationPage />} />
@@ -181,13 +182,7 @@ export default function App() {
       <QueryClientProvider client={queryClient}>
         <Router>
           <ThemeProvider>
-            <Routes>
-              {/* Public routes - rendered OUTSIDE provider tree for reliability */}
-              <Route path="/tools" element={<Tools />} />
-
-              {/* All other routes - with full provider tree */}
-              <Route path="/*" element={<AuthenticatedRoutes />} />
-            </Routes>
+            <AuthenticatedRoutes />
           </ThemeProvider>
         </Router>
       </QueryClientProvider>

--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -1,113 +1,234 @@
 /**
  * Tools Page - External Tools & Applications
- * Completely self-contained - NO external dependencies except React
+ * Follows the standard DashboardLayout pattern like other pages
  */
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { DashboardLayout } from '../components/templates';
+import { useAuth } from '../contexts/AuthContext';
+import { ExternalLink, Sparkles, Zap } from 'lucide-react';
 
-// Inline SVG icons to avoid any import issues
-const ExternalLinkIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-    <polyline points="15 3 21 3 21 9" />
-    <line x1="10" y1="14" x2="21" y2="3" />
+// Inline map icon to avoid any potential issues
+const MapIcon = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polygon points="3 6 9 3 15 6 21 3 21 18 15 21 9 18 3 21" />
+    <line x1="9" y1="3" x2="9" y2="18" />
+    <line x1="15" y1="6" x2="15" y2="21" />
   </svg>
 );
 
-const Tools: React.FC = () => {
+interface Tool {
+  id: string;
+  name: string;
+  description: string;
+  longDescription: string;
+  url: string;
+  category: string;
+  features: string[];
+  isNew?: boolean;
+  isPrimary?: boolean;
+}
+
+const tools: Tool[] = [
+  {
+    id: 'metmap',
+    name: 'MetMap',
+    description: 'AI-powered meeting intelligence platform',
+    longDescription: 'Transform your meetings with AI-driven transcription, smart summaries, and actionable insights. MetMap helps teams capture every important detail and turn conversations into organized, searchable knowledge.',
+    url: 'https://metmap.art',
+    category: 'Productivity',
+    features: [
+      'AI Meeting Transcription',
+      'Smart Summaries',
+      'Action Item Extraction',
+      'Searchable Archives'
+    ],
+    isNew: true,
+    isPrimary: true,
+  },
+];
+
+const ToolCard: React.FC<{ tool: Tool }> = ({ tool }) => {
+  const handleLaunch = () => {
+    window.open(tool.url, '_blank', 'noopener,noreferrer');
+  };
+
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-50">
-      <div className="max-w-5xl mx-auto px-6 py-16">
-        {/* Header */}
-        <header className="mb-10">
-          <div className="flex items-center gap-3">
-            <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-slate-800/80 border border-slate-700">
-              <span className="text-lg" aria-hidden="true">
-                🛠️
-              </span>
-            </span>
-            <div>
-              <h1 className="text-3xl font-semibold tracking-tight">Tools</h1>
-              <p className="text-sm text-slate-400 mt-1">
-                Extend your FluxStudio workflow with external apps and integrations.
-              </p>
+    <div className={`relative group ${tool.isPrimary ? 'md:col-span-2' : ''}`}>
+      <div className={`
+        bg-white dark:bg-neutral-800 rounded-2xl border shadow-sm hover:shadow-lg transition-all duration-300
+        ${tool.isPrimary
+          ? 'border-blue-200 dark:border-blue-800 hover:border-blue-300 dark:hover:border-blue-700'
+          : 'border-neutral-200 dark:border-neutral-700 hover:border-neutral-300 dark:hover:border-neutral-600'
+        }
+      `}>
+        {/* New badge */}
+        {tool.isNew && (
+          <div className="absolute -top-3 -right-3 z-10">
+            <div className="flex items-center gap-1 px-3 py-1 bg-gradient-to-r from-blue-500 to-indigo-500 text-white text-xs font-bold rounded-full shadow-lg">
+              <Sparkles className="w-3 h-3" />
+              NEW
             </div>
           </div>
-        </header>
+        )}
 
-        {/* Featured tool: MetMap */}
-        <section className="mb-10">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-sm font-medium uppercase tracking-[0.18em] text-slate-400">
-              Featured
-            </h2>
-            <span className="inline-flex items-center rounded-full bg-emerald-500/15 text-emerald-300 px-3 py-1 text-xs font-medium border border-emerald-500/40">
-              NEW
-            </span>
-          </div>
+        <div className={`p-6 ${tool.isPrimary ? 'md:p-8' : ''}`}>
+          <div className={`flex ${tool.isPrimary ? 'flex-col md:flex-row md:items-start gap-6' : 'flex-col'}`}>
+            {/* Icon */}
+            <div className={tool.isPrimary ? 'md:flex-shrink-0' : ''}>
+              <div className={`
+                flex items-center justify-center rounded-xl mb-4 md:mb-0
+                ${tool.isPrimary
+                  ? 'w-20 h-20 bg-gradient-to-br from-blue-500 to-indigo-600'
+                  : 'w-16 h-16 bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-900/30 dark:to-indigo-900/30'
+                }
+              `}>
+                <div className={tool.isPrimary ? 'text-white' : 'text-blue-600 dark:text-blue-400'}>
+                  <MapIcon />
+                </div>
+              </div>
+            </div>
 
-          <div className="rounded-2xl border border-slate-800 bg-slate-900/60 shadow-lg shadow-black/40 p-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div className="flex items-start gap-4">
-              <div className="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-sky-500/20 border border-sky-500/40">
-                <span className="text-xl" aria-hidden="true">
-                  🗺️
+            {/* Content */}
+            <div className="flex-1">
+              <div className="flex items-center gap-2 mb-2">
+                <h3 className={`font-bold text-neutral-900 dark:text-neutral-100 ${tool.isPrimary ? 'text-2xl' : 'text-lg'}`}>
+                  {tool.name}
+                </h3>
+                <span className="text-xs text-neutral-500 dark:text-neutral-400 font-medium px-2 py-0.5 bg-neutral-100 dark:bg-neutral-700 rounded-full">
+                  {tool.category}
                 </span>
               </div>
-              <div>
-                <h3 className="text-lg font-semibold">MetMap</h3>
-                <p className="text-sm text-slate-300 mt-1">
-                  AI-powered meeting intelligence platform for musicians and creatives.
-                </p>
-                <ul className="mt-3 text-xs text-slate-400 space-y-1">
-                  <li>• AI Meeting Transcription</li>
-                  <li>• Smart Summaries &amp; action items</li>
-                  <li>• Searchable session archive</li>
-                </ul>
+
+              <p className={`text-neutral-600 dark:text-neutral-300 mb-4 ${tool.isPrimary ? 'text-base' : 'text-sm'}`}>
+                {tool.isPrimary ? tool.longDescription : tool.description}
+              </p>
+
+              {/* Features list for primary tools */}
+              {tool.isPrimary && tool.features.length > 0 && (
+                <div className="mb-6">
+                  <div className="grid grid-cols-2 gap-2">
+                    {tool.features.map((feature, index) => (
+                      <div key={index} className="flex items-center gap-2 text-sm text-neutral-700 dark:text-neutral-300">
+                        <Zap className="w-4 h-4 text-blue-500 flex-shrink-0" />
+                        <span>{feature}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Action buttons */}
+              <div className="flex items-center gap-3 flex-wrap">
+                <button
+                  onClick={handleLaunch}
+                  className={`
+                    flex items-center gap-2 font-medium rounded-lg transition-all duration-200
+                    ${tool.isPrimary
+                      ? 'px-6 py-3 bg-gradient-to-r from-blue-500 to-indigo-600 text-white hover:from-blue-600 hover:to-indigo-700 shadow-md hover:shadow-lg'
+                      : 'px-4 py-2 bg-blue-600 text-white hover:bg-blue-700'
+                    }
+                  `}
+                >
+                  <ExternalLink className="w-4 h-4" />
+                  Launch {tool.name}
+                </button>
+                <a
+                  href={tool.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-sm text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors"
+                >
+                  {tool.url.replace('https://', '')}
+                </a>
               </div>
             </div>
-
-            <div className="mt-4 md:mt-0 flex flex-col items-start md:items-end gap-2">
-              <a
-                href="https://metmap.art"
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-sky-500 to-violet-500 px-4 py-2 text-sm font-medium text-white shadow-md shadow-sky-900/50 hover:opacity-90 transition"
-              >
-                Launch MetMap
-                <ExternalLinkIcon />
-              </a>
-              <p className="text-[11px] text-slate-500">
-                Opens in a new tab: <span className="text-slate-300">metmap.art</span>
-              </p>
-            </div>
           </div>
-        </section>
-
-        {/* Coming soon */}
-        <section>
-          <div className="rounded-2xl border border-slate-800/80 bg-slate-900/70 px-5 py-4">
-            <p className="text-xs font-medium text-sky-300 mb-2">
-              More tools coming soon
-            </p>
-            <p className="text-xs text-slate-300 mb-3">
-              We&apos;re building out a growing toolkit of AI-native helpers for design,
-              project management, and production workflows.
-            </p>
-            <div className="flex flex-wrap gap-2 text-[11px] text-slate-300">
-              <span className="rounded-full bg-slate-800/80 px-3 py-1 border border-slate-700/80">
-                AI Design Assistant
-              </span>
-              <span className="rounded-full bg-slate-800/80 px-3 py-1 border border-slate-700/80">
-                Asset Library
-              </span>
-              <span className="rounded-full bg-slate-800/80 px-3 py-1 border border-slate-700/80">
-                Analytics Dashboard
-              </span>
-            </div>
-          </div>
-        </section>
+        </div>
       </div>
     </div>
   );
 };
 
-export default Tools;
+export default function Tools() {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  // Auth check with redirect
+  useEffect(() => {
+    if (!user) {
+      navigate('/login', { replace: true });
+      return;
+    }
+    document.title = 'Tools - FluxStudio';
+  }, [user, navigate]);
+
+  // Don't render if not authenticated
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <DashboardLayout
+      user={user}
+      breadcrumbs={[{ label: 'Tools' }]}
+      onLogout={logout}
+    >
+      <div className="p-4 md:p-6 space-y-4 md:space-y-6">
+        {/* Header */}
+        <div>
+          <h1 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">
+            Tools
+          </h1>
+          <p className="text-neutral-600 dark:text-neutral-300 mt-1">
+            Extend your FluxStudio workflow with powerful external tools and applications.
+          </p>
+        </div>
+
+        {/* Featured Tools */}
+        <div>
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100 mb-4 flex items-center gap-2">
+            <Sparkles className="w-5 h-5 text-blue-500" />
+            Featured Tools
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {tools.filter(t => t.isPrimary).map((tool) => (
+              <ToolCard key={tool.id} tool={tool} />
+            ))}
+          </div>
+        </div>
+
+        {/* Coming Soon Card */}
+        <div className="bg-gradient-to-br from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20 border border-blue-200 dark:border-blue-800 rounded-2xl p-6">
+          <div className="flex items-start gap-4">
+            <div className="flex-shrink-0">
+              <div className="flex items-center justify-center w-10 h-10 bg-blue-100 dark:bg-blue-900/50 rounded-lg">
+                <Zap className="w-5 h-5 text-blue-600 dark:text-blue-400" />
+              </div>
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-blue-900 dark:text-blue-100 mb-2">
+                More tools coming soon
+              </h3>
+              <p className="text-blue-700 dark:text-blue-300 mb-4 text-sm">
+                We're working on integrating more powerful tools to enhance your creative workflow.
+                Stay tuned for AI design assistants, project management tools, and more.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <span className="px-3 py-1 bg-white/60 dark:bg-neutral-800/60 text-blue-700 dark:text-blue-300 rounded-full text-sm font-medium">
+                  AI Design Assistant
+                </span>
+                <span className="px-3 py-1 bg-white/60 dark:bg-neutral-800/60 text-blue-700 dark:text-blue-300 rounded-full text-sm font-medium">
+                  Asset Library
+                </span>
+                <span className="px-3 py-1 bg-white/60 dark:bg-neutral-800/60 text-blue-700 dark:text-blue-300 rounded-full text-sm font-medium">
+                  Analytics Dashboard
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
…attern

- Rewrote Tools.tsx to use DashboardLayout like Settings, Messages, etc.
- Tools page now shows navigation sidebar and maintains app layout consistency
- Added useAuth() hook for authentication and proper redirect to login
- Moved /tools route inside AuthenticatedRoutes with other pages
- Supports dark mode with proper neutral/blue color scheme
- MetMap tool card with features list, launch button, and NEW badge
- "Coming soon" section with planned tools preview

The Tools page now matches other pages in the app, appearing in the main content area while keeping the sidebar navigation visible.