### PR TITLE
fix(auth): Use correct localStorage key for auth token

### DIFF
--- a/src/services/messagingService.ts
+++ b/src/services/messagingService.ts
@@ -46,11 +46,18 @@ class MessagingService {
    */
   private async apiRequest(endpoint: string, options: RequestInit = {}) {
     const url = `${this.apiBaseUrl}${endpoint}`;
+    // Check both possible token keys for compatibility
+    const authToken = localStorage.getItem('auth_token') || localStorage.getItem('authToken');
+
+    if (!authToken) {
+      console.warn('[MessagingService] No auth token found in localStorage');
+    }
+
     const response = await fetch(url, {
       ...options,
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${localStorage.getItem('authToken')}`,
+        Authorization: `Bearer ${authToken || ''}`,
         ...options.headers,
       },
       credentials: 'include',

--- a/src/services/socketService.ts
+++ b/src/services/socketService.ts
@@ -56,8 +56,8 @@ class SocketService {
    * Updated for unified backend with /messaging namespace
    */
   private connect() {
-    // Don't connect without auth token
-    const authToken = localStorage.getItem('authToken') || localStorage.getItem('auth_token');
+    // Don't connect without auth token (auth_token is the primary key used by AuthContext)
+    const authToken = localStorage.getItem('auth_token') || localStorage.getItem('authToken');
     if (!authToken) {
       console.log('⚠️ No auth token found, skipping Socket.IO connection');
       return;


### PR DESCRIPTION
AuthContext stores the token as 'auth_token', but messagingService was looking for 'authToken'. This caused all messaging API requests to be sent without authentication, resulting in 403 errors.

- messagingService.ts: Check 'auth_token' first (primary key)
- socketService.ts: Check 'auth_token' first for consistency
- Added warning log when no auth token is found