### PR TITLE
feat(boards): Add Design Boards system for 2D collaborative surfaces

### DIFF
--- a/database/design-boards-adapter.js
+++ b/database/design-boards-adapter.js
@@ -1,0 +1,482 @@
+/**
+ * Design Boards Database Adapter - FluxStudio
+ *
+ * Provides database operations for the Design Boards system.
+ * Design boards are 2D collaborative surfaces for placing nodes (text, shapes, assets).
+ *
+ * Features:
+ * - CRUD operations for boards
+ * - Node management (create, update, delete, bulk update)
+ * - Board statistics
+ */
+
+const { query, transaction } = require('./config');
+const { v4: uuidv4 } = require('uuid');
+
+class DesignBoardsAdapter {
+  // ==================== Board Operations ====================
+
+  /**
+   * Create a new design board
+   *
+   * @param {Object} boardData
+   * @returns {Object} Created board record
+   */
+  async createBoard({
+    projectId,
+    organizationId,
+    ownerId,
+    name,
+    description
+  }) {
+    const id = uuidv4();
+
+    const result = await query(`
+      INSERT INTO design_boards (
+        id, project_id, organization_id, owner_id, name, description,
+        is_archived, created_at, updated_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, FALSE, NOW(), NOW())
+      RETURNING *
+    `, [
+      id,
+      projectId,
+      organizationId || null,
+      ownerId,
+      name,
+      description || null
+    ]);
+
+    return this._transformBoard(result.rows[0]);
+  }
+
+  /**
+   * Get board by ID (without nodes)
+   *
+   * @param {string} boardId
+   * @returns {Object|null} Board record
+   */
+  async getBoardById(boardId) {
+    const result = await query(`
+      SELECT
+        b.*,
+        u.name as owner_name,
+        p.name as project_name,
+        (SELECT COUNT(*) FROM design_board_nodes WHERE board_id = b.id) as node_count
+      FROM design_boards b
+      LEFT JOIN users u ON b.owner_id = u.id
+      LEFT JOIN projects p ON b.project_id = p.id
+      WHERE b.id = $1
+    `, [boardId]);
+
+    if (result.rows.length === 0) return null;
+    return this._transformBoard(result.rows[0]);
+  }
+
+  /**
+   * List boards for a project
+   *
+   * @param {Object} options
+   * @returns {Array} Array of boards
+   */
+  async listBoardsForProject({ projectId, includeArchived = false }) {
+    const conditions = ['b.project_id = $1'];
+    const params = [projectId];
+
+    if (!includeArchived) {
+      conditions.push('b.is_archived = FALSE');
+    }
+
+    const result = await query(`
+      SELECT
+        b.*,
+        u.name as owner_name,
+        (SELECT COUNT(*) FROM design_board_nodes WHERE board_id = b.id) as node_count
+      FROM design_boards b
+      LEFT JOIN users u ON b.owner_id = u.id
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY b.created_at DESC
+    `, params);
+
+    return result.rows.map(row => this._transformBoard(row));
+  }
+
+  /**
+   * Update board metadata
+   *
+   * @param {string} boardId
+   * @param {Object} updates
+   * @returns {Object|null} Updated board
+   */
+  async updateBoard(boardId, { name, description, isArchived, thumbnailAssetId }) {
+    const setClauses = ['updated_at = NOW()'];
+    const params = [];
+    let paramIndex = 1;
+
+    if (name !== undefined) {
+      setClauses.push(`name = $${paramIndex}`);
+      params.push(name);
+      paramIndex++;
+    }
+
+    if (description !== undefined) {
+      setClauses.push(`description = $${paramIndex}`);
+      params.push(description);
+      paramIndex++;
+    }
+
+    if (isArchived !== undefined) {
+      setClauses.push(`is_archived = $${paramIndex}`);
+      params.push(isArchived);
+      paramIndex++;
+    }
+
+    if (thumbnailAssetId !== undefined) {
+      setClauses.push(`thumbnail_asset_id = $${paramIndex}`);
+      params.push(thumbnailAssetId);
+      paramIndex++;
+    }
+
+    params.push(boardId);
+
+    const result = await query(`
+      UPDATE design_boards
+      SET ${setClauses.join(', ')}
+      WHERE id = $${paramIndex}
+      RETURNING *
+    `, params);
+
+    if (result.rows.length === 0) return null;
+    return this._transformBoard(result.rows[0]);
+  }
+
+  /**
+   * Delete a board (and all nodes via CASCADE)
+   *
+   * @param {string} boardId
+   * @returns {boolean} Success
+   */
+  async deleteBoard(boardId) {
+    const result = await query(
+      'DELETE FROM design_boards WHERE id = $1 RETURNING id',
+      [boardId]
+    );
+    return result.rows.length > 0;
+  }
+
+  // ==================== Node Operations ====================
+
+  /**
+   * Create a new node on a board
+   *
+   * @param {Object} nodeData
+   * @returns {Object} Created node record
+   */
+  async createNode({
+    boardId,
+    type,
+    assetId,
+    x = 0,
+    y = 0,
+    width,
+    height,
+    zIndex = 0,
+    rotation = 0,
+    locked = false,
+    data = {}
+  }) {
+    const id = uuidv4();
+
+    // If no zIndex provided, get the max zIndex for this board and add 1
+    let finalZIndex = zIndex;
+    if (zIndex === 0) {
+      const maxResult = await query(
+        'SELECT COALESCE(MAX(z_index), 0) as max_z FROM design_board_nodes WHERE board_id = $1',
+        [boardId]
+      );
+      finalZIndex = parseInt(maxResult.rows[0].max_z, 10) + 1;
+    }
+
+    const result = await query(`
+      INSERT INTO design_board_nodes (
+        id, board_id, type, asset_id, z_index, x, y, width, height,
+        rotation, locked, data, created_at, updated_at
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW(), NOW())
+      RETURNING *
+    `, [
+      id,
+      boardId,
+      type,
+      assetId || null,
+      finalZIndex,
+      x,
+      y,
+      width || null,
+      height || null,
+      rotation,
+      locked,
+      JSON.stringify(data)
+    ]);
+
+    return this._transformNode(result.rows[0]);
+  }
+
+  /**
+   * Get all nodes for a board
+   *
+   * @param {string} boardId
+   * @returns {Array} Array of nodes sorted by z_index
+   */
+  async getNodesForBoard(boardId) {
+    const result = await query(`
+      SELECT
+        n.*,
+        a.name as asset_name,
+        a.kind as asset_kind,
+        a.primary_file_id,
+        f.file_url as asset_file_url,
+        f.thumbnail_url as asset_thumbnail_url,
+        f.mime_type as asset_mime_type
+      FROM design_board_nodes n
+      LEFT JOIN assets a ON n.asset_id = a.id
+      LEFT JOIN files f ON a.primary_file_id = f.id
+      WHERE n.board_id = $1
+      ORDER BY n.z_index ASC
+    `, [boardId]);
+
+    return result.rows.map(row => this._transformNode(row));
+  }
+
+  /**
+   * Update a single node
+   *
+   * @param {string} nodeId
+   * @param {Object} patch
+   * @returns {Object|null} Updated node
+   */
+  async updateNode(nodeId, patch) {
+    const setClauses = ['updated_at = NOW()'];
+    const params = [];
+    let paramIndex = 1;
+
+    const allowedFields = ['x', 'y', 'width', 'height', 'z_index', 'rotation', 'locked', 'data'];
+    const fieldMap = {
+      x: 'x',
+      y: 'y',
+      width: 'width',
+      height: 'height',
+      zIndex: 'z_index',
+      rotation: 'rotation',
+      locked: 'locked',
+      data: 'data'
+    };
+
+    for (const [key, value] of Object.entries(patch)) {
+      const dbField = fieldMap[key];
+      if (dbField && value !== undefined) {
+        setClauses.push(`${dbField} = $${paramIndex}`);
+        params.push(key === 'data' ? JSON.stringify(value) : value);
+        paramIndex++;
+      }
+    }
+
+    if (params.length === 0) {
+      // No fields to update, return existing node
+      const existing = await query('SELECT * FROM design_board_nodes WHERE id = $1', [nodeId]);
+      return existing.rows.length > 0 ? this._transformNode(existing.rows[0]) : null;
+    }
+
+    params.push(nodeId);
+
+    const result = await query(`
+      UPDATE design_board_nodes
+      SET ${setClauses.join(', ')}
+      WHERE id = $${paramIndex}
+      RETURNING *
+    `, params);
+
+    if (result.rows.length === 0) return null;
+    return this._transformNode(result.rows[0]);
+  }
+
+  /**
+   * Delete a node
+   *
+   * @param {string} nodeId
+   * @returns {boolean} Success
+   */
+  async deleteNode(nodeId) {
+    const result = await query(
+      'DELETE FROM design_board_nodes WHERE id = $1 RETURNING id',
+      [nodeId]
+    );
+    return result.rows.length > 0;
+  }
+
+  /**
+   * Bulk update node positions
+   *
+   * @param {string} boardId
+   * @param {Array} updates - Array of { id, x, y, zIndex? }
+   * @returns {boolean} Success
+   */
+  async bulkUpdateNodePositions(boardId, updates) {
+    if (!updates || updates.length === 0) return true;
+
+    // Use a single transaction for all updates
+    for (const update of updates) {
+      const setClauses = ['updated_at = NOW()'];
+      const params = [];
+      let paramIndex = 1;
+
+      if (update.x !== undefined) {
+        setClauses.push(`x = $${paramIndex}`);
+        params.push(update.x);
+        paramIndex++;
+      }
+
+      if (update.y !== undefined) {
+        setClauses.push(`y = $${paramIndex}`);
+        params.push(update.y);
+        paramIndex++;
+      }
+
+      if (update.zIndex !== undefined) {
+        setClauses.push(`z_index = $${paramIndex}`);
+        params.push(update.zIndex);
+        paramIndex++;
+      }
+
+      if (params.length > 0) {
+        params.push(update.id);
+        params.push(boardId);
+
+        await query(`
+          UPDATE design_board_nodes
+          SET ${setClauses.join(', ')}
+          WHERE id = $${paramIndex} AND board_id = $${paramIndex + 1}
+        `, params);
+      }
+    }
+
+    return true;
+  }
+
+  // ==================== Statistics ====================
+
+  /**
+   * Get board statistics for a project
+   *
+   * @param {string} projectId
+   * @returns {Object} Stats
+   */
+  async getBoardStatsForProject(projectId) {
+    const result = await query(`
+      SELECT
+        COUNT(DISTINCT b.id) as board_count,
+        COUNT(n.id) as node_count
+      FROM design_boards b
+      LEFT JOIN design_board_nodes n ON n.board_id = b.id
+      WHERE b.project_id = $1 AND b.is_archived = FALSE
+    `, [projectId]);
+
+    const row = result.rows[0];
+    return {
+      boardCount: parseInt(row.board_count, 10),
+      nodeCount: parseInt(row.node_count, 10)
+    };
+  }
+
+  // ==================== Events (Audit Log) ====================
+
+  /**
+   * Log a board event
+   *
+   * @param {Object} eventData
+   * @returns {Object} Created event
+   */
+  async logEvent({
+    boardId,
+    userId,
+    eventType,
+    payload
+  }) {
+    const id = uuidv4();
+
+    const result = await query(`
+      INSERT INTO design_board_events (id, board_id, user_id, event_type, payload, created_at)
+      VALUES ($1, $2, $3, $4, $5, NOW())
+      RETURNING *
+    `, [id, boardId, userId, eventType, JSON.stringify(payload)]);
+
+    return result.rows[0];
+  }
+
+  // ==================== Helper Methods ====================
+
+  /**
+   * Transform database row to API response format for board
+   */
+  _transformBoard(row) {
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      projectId: row.project_id,
+      projectName: row.project_name,
+      organizationId: row.organization_id,
+      ownerId: row.owner_id,
+      ownerName: row.owner_name,
+      name: row.name,
+      description: row.description,
+      thumbnailAssetId: row.thumbnail_asset_id,
+      isArchived: row.is_archived,
+      nodeCount: row.node_count !== undefined ? parseInt(row.node_count, 10) : 0,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    };
+  }
+
+  /**
+   * Transform database row to API response format for node
+   */
+  _transformNode(row) {
+    if (!row) return null;
+
+    const node = {
+      id: row.id,
+      boardId: row.board_id,
+      type: row.type,
+      assetId: row.asset_id,
+      zIndex: row.z_index,
+      x: parseFloat(row.x),
+      y: parseFloat(row.y),
+      width: row.width ? parseFloat(row.width) : null,
+      height: row.height ? parseFloat(row.height) : null,
+      rotation: parseFloat(row.rotation),
+      locked: row.locked,
+      data: typeof row.data === 'string' ? JSON.parse(row.data) : (row.data || {}),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    };
+
+    // Include asset info if present
+    if (row.asset_name) {
+      node.asset = {
+        id: row.asset_id,
+        name: row.asset_name,
+        kind: row.asset_kind,
+        fileUrl: row.asset_file_url,
+        thumbnailUrl: row.asset_thumbnail_url,
+        mimeType: row.asset_mime_type
+      };
+    }
+
+    return node;
+  }
+}
+
+// Export singleton instance
+const designBoardsAdapter = new DesignBoardsAdapter();
+module.exports = designBoardsAdapter;

--- a/database/migrations/036_create_design_boards.sql
+++ b/database/migrations/036_create_design_boards.sql
@@ -1,0 +1,82 @@
+-- Migration 036: Add Design Boards System Tables
+-- Date: 2025-12-12
+-- Description: Creates design_boards, design_board_nodes, and design_board_events tables
+--              Design boards are 2D collaborative surfaces for placing nodes (text, shapes, assets)
+
+-- Design boards table - 2D collaborative surfaces attached to projects
+CREATE TABLE IF NOT EXISTS design_boards (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  organization_id TEXT,
+  owner_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  thumbnail_asset_id TEXT,
+  is_archived BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for design_boards table
+CREATE INDEX IF NOT EXISTS idx_design_boards_project ON design_boards(project_id);
+CREATE INDEX IF NOT EXISTS idx_design_boards_org_archived ON design_boards(organization_id, is_archived);
+CREATE INDEX IF NOT EXISTS idx_design_boards_owner ON design_boards(owner_id);
+
+-- Design board nodes table - items placed on a board
+CREATE TABLE IF NOT EXISTS design_board_nodes (
+  id TEXT PRIMARY KEY,
+  board_id TEXT NOT NULL REFERENCES design_boards(id) ON DELETE CASCADE,
+  type TEXT NOT NULL,
+  asset_id TEXT,
+  z_index INTEGER NOT NULL DEFAULT 0,
+  x NUMERIC NOT NULL DEFAULT 0,
+  y NUMERIC NOT NULL DEFAULT 0,
+  width NUMERIC,
+  height NUMERIC,
+  rotation NUMERIC NOT NULL DEFAULT 0,
+  locked BOOLEAN NOT NULL DEFAULT FALSE,
+  data JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for design_board_nodes table
+CREATE INDEX IF NOT EXISTS idx_design_board_nodes_board ON design_board_nodes(board_id);
+CREATE INDEX IF NOT EXISTS idx_design_board_nodes_board_zindex ON design_board_nodes(board_id, z_index);
+CREATE INDEX IF NOT EXISTS idx_design_board_nodes_asset ON design_board_nodes(asset_id);
+CREATE INDEX IF NOT EXISTS idx_design_board_nodes_type ON design_board_nodes(type);
+
+-- Design board events table - audit log for board changes
+CREATE TABLE IF NOT EXISTS design_board_events (
+  id TEXT PRIMARY KEY,
+  board_id TEXT NOT NULL REFERENCES design_boards(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for design_board_events table
+CREATE INDEX IF NOT EXISTS idx_design_board_events_board ON design_board_events(board_id);
+CREATE INDEX IF NOT EXISTS idx_design_board_events_board_created ON design_board_events(board_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_design_board_events_user ON design_board_events(user_id);
+
+-- Add comments
+COMMENT ON TABLE design_boards IS '2D collaborative surfaces attached to projects for visual layouts';
+COMMENT ON COLUMN design_boards.project_id IS 'The project this board belongs to';
+COMMENT ON COLUMN design_boards.thumbnail_asset_id IS 'Optional asset to use as board thumbnail';
+COMMENT ON COLUMN design_boards.is_archived IS 'Whether the board is archived (hidden but not deleted)';
+
+COMMENT ON TABLE design_board_nodes IS 'Items placed on a design board (text, shapes, assets)';
+COMMENT ON COLUMN design_board_nodes.type IS 'Node type: text, asset, shape';
+COMMENT ON COLUMN design_board_nodes.asset_id IS 'Reference to asset if type is asset';
+COMMENT ON COLUMN design_board_nodes.z_index IS 'Stacking order (higher = on top)';
+COMMENT ON COLUMN design_board_nodes.x IS 'X position on the board';
+COMMENT ON COLUMN design_board_nodes.y IS 'Y position on the board';
+COMMENT ON COLUMN design_board_nodes.rotation IS 'Rotation in degrees';
+COMMENT ON COLUMN design_board_nodes.locked IS 'Whether the node is locked from editing';
+COMMENT ON COLUMN design_board_nodes.data IS 'Type-specific data (text content, colors, shape type, etc.)';
+
+COMMENT ON TABLE design_board_events IS 'Audit log of board changes for collaboration and history';
+COMMENT ON COLUMN design_board_events.event_type IS 'Event type: node_created, node_updated, node_deleted, board_updated';
+COMMENT ON COLUMN design_board_events.payload IS 'Event-specific data (node id, changes, etc.)';

--- a/server-unified.js
+++ b/server-unified.js
@@ -125,9 +125,11 @@ performanceMonitor.monitorWebSocket(io, 'unified-service');
 const authNamespace = io.of('/auth');
 const messagingNamespace = io.of('/messaging');
 const printingNamespace = io.of('/printing'); // Phase 3A: Real-time printing updates
+const designBoardsNamespace = io.of('/design-boards'); // Design boards real-time collaboration
 
-// Store printing namespace in app for access in routes (Phase 4A)
+// Store namespaces in app for access in routes
 app.set('printingNamespace', printingNamespace);
+app.set('designBoardsNamespace', designBoardsNamespace);
 
 // Google OAuth configuration
 const GOOGLE_CLIENT_ID = config.GOOGLE_CLIENT_ID;
@@ -2772,6 +2774,7 @@ app.get('/files/storage/*storageKey', authenticateToken, async (req, res) => {
 
 const assetsAdapter = require('./database/assets-adapter');
 const { determineAssetKind } = require('./database/assets-adapter');
+const designBoardsAdapter = require('./database/design-boards-adapter');
 
 // 1. GET /api/assets - List assets with filtering
 app.get('/api/assets', authenticateToken, async (req, res) => {
@@ -3053,6 +3056,301 @@ app.get('/api/projects/:projectId/assets', authenticateToken, async (req, res) =
   } catch (error) {
     console.error('Error getting project assets:', error);
     res.status(500).json({ success: false, error: 'Failed to get project assets' });
+  }
+});
+
+// ========================================
+// DESIGN BOARDS API (2D Collaborative Surfaces)
+// ========================================
+
+// 1. GET /api/projects/:projectId/boards - List boards for a project
+app.get('/api/projects/:projectId/boards', authenticateToken, async (req, res) => {
+  try {
+    const { projectId } = req.params;
+    const { includeArchived } = req.query;
+
+    const boards = await designBoardsAdapter.listBoardsForProject({
+      projectId,
+      includeArchived: includeArchived === 'true'
+    });
+
+    res.json({ success: true, boards });
+  } catch (error) {
+    console.error('Error listing boards:', error);
+    res.status(500).json({ success: false, error: 'Failed to list boards' });
+  }
+});
+
+// 2. POST /api/projects/:projectId/boards - Create a new board
+app.post('/api/projects/:projectId/boards', authenticateToken, async (req, res) => {
+  try {
+    const { projectId } = req.params;
+    const { name, description, organizationId } = req.body;
+
+    if (!name || name.trim().length === 0) {
+      return res.status(400).json({ success: false, error: 'Board name is required' });
+    }
+
+    const board = await designBoardsAdapter.createBoard({
+      projectId,
+      organizationId,
+      ownerId: req.user.id,
+      name: name.trim(),
+      description
+    });
+
+    // Log the creation event
+    await designBoardsAdapter.logEvent({
+      boardId: board.id,
+      userId: req.user.id,
+      eventType: 'board_created',
+      payload: { name: board.name }
+    });
+
+    res.status(201).json({ success: true, board });
+  } catch (error) {
+    console.error('Error creating board:', error);
+    res.status(500).json({ success: false, error: 'Failed to create board' });
+  }
+});
+
+// 3. GET /api/boards/:boardId - Get a single board with nodes
+app.get('/api/boards/:boardId', authenticateToken, async (req, res) => {
+  try {
+    const { boardId } = req.params;
+
+    const board = await designBoardsAdapter.getBoardById(boardId);
+    if (!board) {
+      return res.status(404).json({ success: false, error: 'Board not found' });
+    }
+
+    const nodes = await designBoardsAdapter.getNodesForBoard(boardId);
+
+    res.json({ success: true, board, nodes });
+  } catch (error) {
+    console.error('Error getting board:', error);
+    res.status(500).json({ success: false, error: 'Failed to get board' });
+  }
+});
+
+// 4. PATCH /api/boards/:boardId - Update board metadata
+app.patch('/api/boards/:boardId', authenticateToken, async (req, res) => {
+  try {
+    const { boardId } = req.params;
+    const { name, description, isArchived, thumbnailAssetId } = req.body;
+
+    const board = await designBoardsAdapter.getBoardById(boardId);
+    if (!board) {
+      return res.status(404).json({ success: false, error: 'Board not found' });
+    }
+
+    const updatedBoard = await designBoardsAdapter.updateBoard(boardId, {
+      name,
+      description,
+      isArchived,
+      thumbnailAssetId
+    });
+
+    // Log the update event
+    await designBoardsAdapter.logEvent({
+      boardId,
+      userId: req.user.id,
+      eventType: 'board_updated',
+      payload: { changes: { name, description, isArchived, thumbnailAssetId } }
+    });
+
+    res.json({ success: true, board: updatedBoard });
+  } catch (error) {
+    console.error('Error updating board:', error);
+    res.status(500).json({ success: false, error: 'Failed to update board' });
+  }
+});
+
+// 5. DELETE /api/boards/:boardId - Delete a board
+app.delete('/api/boards/:boardId', authenticateToken, async (req, res) => {
+  try {
+    const { boardId } = req.params;
+
+    const board = await designBoardsAdapter.getBoardById(boardId);
+    if (!board) {
+      return res.status(404).json({ success: false, error: 'Board not found' });
+    }
+
+    await designBoardsAdapter.deleteBoard(boardId);
+
+    res.json({ success: true, message: 'Board deleted' });
+  } catch (error) {
+    console.error('Error deleting board:', error);
+    res.status(500).json({ success: false, error: 'Failed to delete board' });
+  }
+});
+
+// 6. POST /api/boards/:boardId/nodes - Create a node on a board
+app.post('/api/boards/:boardId/nodes', authenticateToken, async (req, res) => {
+  try {
+    const { boardId } = req.params;
+    const { type, assetId, x, y, width, height, zIndex, rotation, locked, data } = req.body;
+
+    if (!type) {
+      return res.status(400).json({ success: false, error: 'Node type is required' });
+    }
+
+    const validTypes = ['text', 'asset', 'shape'];
+    if (!validTypes.includes(type)) {
+      return res.status(400).json({ success: false, error: `Invalid node type. Must be one of: ${validTypes.join(', ')}` });
+    }
+
+    if (type === 'asset' && !assetId) {
+      return res.status(400).json({ success: false, error: 'Asset ID is required for asset nodes' });
+    }
+
+    const board = await designBoardsAdapter.getBoardById(boardId);
+    if (!board) {
+      return res.status(404).json({ success: false, error: 'Board not found' });
+    }
+
+    const node = await designBoardsAdapter.createNode({
+      boardId,
+      type,
+      assetId,
+      x: x ?? 0,
+      y: y ?? 0,
+      width,
+      height,
+      zIndex: zIndex ?? 0,
+      rotation: rotation ?? 0,
+      locked: locked ?? false,
+      data: data ?? {}
+    });
+
+    // Log the creation event
+    await designBoardsAdapter.logEvent({
+      boardId,
+      userId: req.user.id,
+      eventType: 'node_created',
+      payload: { nodeId: node.id, type, assetId }
+    });
+
+    res.status(201).json({ success: true, node });
+  } catch (error) {
+    console.error('Error creating node:', error);
+    res.status(500).json({ success: false, error: 'Failed to create node' });
+  }
+});
+
+// 7. PATCH /api/boards/:boardId/nodes/:nodeId - Update a node
+app.patch('/api/boards/:boardId/nodes/:nodeId', authenticateToken, async (req, res) => {
+  try {
+    const { boardId, nodeId } = req.params;
+    const patch = req.body;
+
+    // Validate the board exists
+    const board = await designBoardsAdapter.getBoardById(boardId);
+    if (!board) {
+      return res.status(404).json({ success: false, error: 'Board not found' });
+    }
+
+    const updatedNode = await designBoardsAdapter.updateNode(nodeId, patch);
+    if (!updatedNode) {
+      return res.status(404).json({ success: false, error: 'Node not found' });
+    }
+
+    // Log the update event
+    await designBoardsAdapter.logEvent({
+      boardId,
+      userId: req.user.id,
+      eventType: 'node_updated',
+      payload: { nodeId, changes: patch }
+    });
+
+    res.json({ success: true, node: updatedNode });
+  } catch (error) {
+    console.error('Error updating node:', error);
+    res.status(500).json({ success: false, error: 'Failed to update node' });
+  }
+});
+
+// 8. DELETE /api/boards/:boardId/nodes/:nodeId - Delete a node
+app.delete('/api/boards/:boardId/nodes/:nodeId', authenticateToken, async (req, res) => {
+  try {
+    const { boardId, nodeId } = req.params;
+
+    // Validate the board exists
+    const board = await designBoardsAdapter.getBoardById(boardId);
+    if (!board) {
+      return res.status(404).json({ success: false, error: 'Board not found' });
+    }
+
+    const deleted = await designBoardsAdapter.deleteNode(nodeId);
+    if (!deleted) {
+      return res.status(404).json({ success: false, error: 'Node not found' });
+    }
+
+    // Log the deletion event
+    await designBoardsAdapter.logEvent({
+      boardId,
+      userId: req.user.id,
+      eventType: 'node_deleted',
+      payload: { nodeId }
+    });
+
+    res.json({ success: true, message: 'Node deleted' });
+  } catch (error) {
+    console.error('Error deleting node:', error);
+    res.status(500).json({ success: false, error: 'Failed to delete node' });
+  }
+});
+
+// 9. POST /api/boards/:boardId/nodes/bulk-position - Bulk update node positions
+app.post('/api/boards/:boardId/nodes/bulk-position', authenticateToken, async (req, res) => {
+  try {
+    const { boardId } = req.params;
+    const { updates } = req.body;
+
+    if (!Array.isArray(updates) || updates.length === 0) {
+      return res.status(400).json({ success: false, error: 'Updates array is required' });
+    }
+
+    // Validate update format
+    for (const update of updates) {
+      if (!update.nodeId) {
+        return res.status(400).json({ success: false, error: 'Each update must have a nodeId' });
+      }
+    }
+
+    const board = await designBoardsAdapter.getBoardById(boardId);
+    if (!board) {
+      return res.status(404).json({ success: false, error: 'Board not found' });
+    }
+
+    const updatedNodes = await designBoardsAdapter.bulkUpdateNodePositions(boardId, updates);
+
+    // Log the bulk update event
+    await designBoardsAdapter.logEvent({
+      boardId,
+      userId: req.user.id,
+      eventType: 'nodes_repositioned',
+      payload: { count: updates.length, nodeIds: updates.map(u => u.nodeId) }
+    });
+
+    res.json({ success: true, nodes: updatedNodes });
+  } catch (error) {
+    console.error('Error bulk updating nodes:', error);
+    res.status(500).json({ success: false, error: 'Failed to bulk update nodes' });
+  }
+});
+
+// 10. GET /api/projects/:projectId/boards/stats - Get board stats for a project
+app.get('/api/projects/:projectId/boards/stats', authenticateToken, async (req, res) => {
+  try {
+    const { projectId } = req.params;
+
+    const stats = await designBoardsAdapter.getBoardStatsForProject(projectId);
+
+    res.json({ success: true, stats });
+  } catch (error) {
+    console.error('Error getting board stats:', error);
+    res.status(500).json({ success: false, error: 'Failed to get board stats' });
   }
 });
 
@@ -5880,6 +6178,7 @@ app.use(createHealthCheck({
 require('./sockets/auth-socket')(authNamespace, performanceMonitor, authAdapter);
 require('./sockets/messaging-socket')(messagingNamespace, createMessage, getMessages, getChannels, messagingAdapter, JWT_SECRET);
 require('./sockets/printing-socket')(printingNamespace, JWT_SECRET); // Phase 3A + Security: Real-time printing updates with JWT auth
+require('./sockets/design-boards-socket')(designBoardsNamespace, designBoardsAdapter, JWT_SECRET); // Design boards real-time collaboration
 
 // ============================================================================
 // FluxPrint Integration - 3D Printing Proxy Layer (Phase 1 + Phase 2.5)
@@ -7342,6 +7641,7 @@ httpServer.listen(PORT, async () => {
   console.log(`📡 Server running on port ${PORT}`);
   console.log(`🔐 Auth namespace: ws://localhost:${PORT}/auth`);
   console.log(`💬 Messaging namespace: ws://localhost:${PORT}/messaging`);
+  console.log(`🎨 Design Boards namespace: ws://localhost:${PORT}/design-boards`);
   console.log(`🏥 Health check: http://localhost:${PORT}/health`);
   console.log(`📊 Monitoring: http://localhost:${PORT}/api/monitoring`);
   console.log('');

--- a/sockets/design-boards-socket.js
+++ b/sockets/design-boards-socket.js
@@ -1,0 +1,347 @@
+/**
+ * Design Boards Socket.IO Namespace Handler
+ * Real-time collaboration for 2D design boards
+ *
+ * Namespace: /design-boards
+ * Purpose: Real-time node updates, cursor positions, board collaboration
+ */
+
+const jwt = require('jsonwebtoken');
+
+module.exports = (namespace, designBoardsAdapter, JWT_SECRET) => {
+  // Store active board sessions
+  const boardSessions = new Map(); // boardId -> Set of { socketId, userId, userEmail, cursor }
+
+  // Authentication middleware for Socket.IO namespace
+  namespace.use(async (socket, next) => {
+    try {
+      const token = socket.handshake.auth.token;
+      if (!token) {
+        return next(new Error('Authentication required'));
+      }
+
+      const decoded = jwt.verify(token, JWT_SECRET);
+      socket.userId = decoded.id;
+      socket.userEmail = decoded.email;
+      next();
+    } catch (err) {
+      next(new Error('Invalid token'));
+    }
+  });
+
+  // Helper: Get users in a board room
+  const getBoardUsers = (boardId) => {
+    const session = boardSessions.get(boardId);
+    if (!session) return [];
+    return Array.from(session.values()).map(({ userId, userEmail, cursor }) => ({
+      userId,
+      userEmail,
+      cursor
+    }));
+  };
+
+  // Helper: Broadcast to board room except sender
+  const broadcastToBoard = (socket, boardId, event, data) => {
+    socket.to(`board:${boardId}`).emit(event, data);
+  };
+
+  // Socket.IO connection handling
+  namespace.on('connection', async (socket) => {
+    console.log(`[Design Boards] User connected: ${socket.userId}`);
+
+    // Join a board for real-time collaboration
+    socket.on('board:join', async (boardId) => {
+      try {
+        // Verify board exists
+        const board = await designBoardsAdapter.getBoardById(boardId);
+        if (!board) {
+          socket.emit('error', { message: 'Board not found' });
+          return;
+        }
+
+        // Join the board room
+        socket.join(`board:${boardId}`);
+        socket.currentBoardId = boardId;
+
+        // Track user in board session
+        if (!boardSessions.has(boardId)) {
+          boardSessions.set(boardId, new Map());
+        }
+        boardSessions.get(boardId).set(socket.id, {
+          userId: socket.userId,
+          userEmail: socket.userEmail,
+          cursor: null
+        });
+
+        console.log(`[Design Boards] User ${socket.userId} joined board ${boardId}`);
+
+        // Notify others in the room
+        broadcastToBoard(socket, boardId, 'board:user-joined', {
+          userId: socket.userId,
+          userEmail: socket.userEmail
+        });
+
+        // Send current board state and users to the joining user
+        const nodes = await designBoardsAdapter.getNodesForBoard(boardId);
+        socket.emit('board:joined', {
+          board,
+          nodes,
+          users: getBoardUsers(boardId)
+        });
+      } catch (error) {
+        console.error('[Design Boards] Error joining board:', error);
+        socket.emit('error', { message: 'Failed to join board' });
+      }
+    });
+
+    // Leave a board
+    socket.on('board:leave', (boardId) => {
+      socket.leave(`board:${boardId}`);
+
+      // Remove from board session
+      const session = boardSessions.get(boardId);
+      if (session) {
+        session.delete(socket.id);
+        if (session.size === 0) {
+          boardSessions.delete(boardId);
+        }
+      }
+
+      socket.currentBoardId = null;
+
+      console.log(`[Design Boards] User ${socket.userId} left board ${boardId}`);
+
+      // Notify others in the room
+      broadcastToBoard(socket, boardId, 'board:user-left', {
+        userId: socket.userId
+      });
+    });
+
+    // Update cursor position (for showing collaborator cursors)
+    socket.on('cursor:move', (data) => {
+      const { boardId, x, y } = data;
+
+      // Update session cursor
+      const session = boardSessions.get(boardId);
+      if (session && session.has(socket.id)) {
+        session.get(socket.id).cursor = { x, y };
+      }
+
+      // Broadcast to others
+      broadcastToBoard(socket, boardId, 'cursor:moved', {
+        userId: socket.userId,
+        userEmail: socket.userEmail,
+        x,
+        y
+      });
+    });
+
+    // Node created
+    socket.on('node:create', async (data) => {
+      const { boardId, node } = data;
+
+      try {
+        const createdNode = await designBoardsAdapter.createNode({
+          boardId,
+          type: node.type,
+          assetId: node.assetId,
+          x: node.x ?? 0,
+          y: node.y ?? 0,
+          width: node.width,
+          height: node.height,
+          zIndex: node.zIndex ?? 0,
+          rotation: node.rotation ?? 0,
+          locked: node.locked ?? false,
+          data: node.data ?? {}
+        });
+
+        // Log event
+        await designBoardsAdapter.logEvent({
+          boardId,
+          userId: socket.userId,
+          eventType: 'node_created',
+          payload: { nodeId: createdNode.id, type: node.type }
+        });
+
+        // Broadcast to all (including sender for confirmation)
+        namespace.to(`board:${boardId}`).emit('node:created', {
+          node: createdNode,
+          userId: socket.userId
+        });
+      } catch (error) {
+        console.error('[Design Boards] Error creating node:', error);
+        socket.emit('error', { message: 'Failed to create node' });
+      }
+    });
+
+    // Node updated (position, size, rotation, data)
+    socket.on('node:update', async (data) => {
+      const { boardId, nodeId, patch } = data;
+
+      try {
+        const updatedNode = await designBoardsAdapter.updateNode(nodeId, patch);
+
+        if (!updatedNode) {
+          socket.emit('error', { message: 'Node not found' });
+          return;
+        }
+
+        // Log event
+        await designBoardsAdapter.logEvent({
+          boardId,
+          userId: socket.userId,
+          eventType: 'node_updated',
+          payload: { nodeId, changes: Object.keys(patch) }
+        });
+
+        // Broadcast to all (including sender for confirmation)
+        namespace.to(`board:${boardId}`).emit('node:updated', {
+          node: updatedNode,
+          userId: socket.userId
+        });
+      } catch (error) {
+        console.error('[Design Boards] Error updating node:', error);
+        socket.emit('error', { message: 'Failed to update node' });
+      }
+    });
+
+    // Node deleted
+    socket.on('node:delete', async (data) => {
+      const { boardId, nodeId } = data;
+
+      try {
+        const deleted = await designBoardsAdapter.deleteNode(nodeId);
+
+        if (!deleted) {
+          socket.emit('error', { message: 'Node not found' });
+          return;
+        }
+
+        // Log event
+        await designBoardsAdapter.logEvent({
+          boardId,
+          userId: socket.userId,
+          eventType: 'node_deleted',
+          payload: { nodeId }
+        });
+
+        // Broadcast to all
+        namespace.to(`board:${boardId}`).emit('node:deleted', {
+          nodeId,
+          userId: socket.userId
+        });
+      } catch (error) {
+        console.error('[Design Boards] Error deleting node:', error);
+        socket.emit('error', { message: 'Failed to delete node' });
+      }
+    });
+
+    // Bulk node position update (for multi-select drag)
+    socket.on('nodes:bulk-position', async (data) => {
+      const { boardId, updates } = data;
+
+      try {
+        const updatedNodes = await designBoardsAdapter.bulkUpdateNodePositions(boardId, updates);
+
+        // Log event
+        await designBoardsAdapter.logEvent({
+          boardId,
+          userId: socket.userId,
+          eventType: 'nodes_repositioned',
+          payload: { count: updates.length, nodeIds: updates.map(u => u.nodeId) }
+        });
+
+        // Broadcast to all
+        namespace.to(`board:${boardId}`).emit('nodes:bulk-updated', {
+          nodes: updatedNodes,
+          userId: socket.userId
+        });
+      } catch (error) {
+        console.error('[Design Boards] Error bulk updating nodes:', error);
+        socket.emit('error', { message: 'Failed to bulk update nodes' });
+      }
+    });
+
+    // Node selection (show what other users have selected)
+    socket.on('node:select', (data) => {
+      const { boardId, nodeId } = data;
+
+      broadcastToBoard(socket, boardId, 'node:selected', {
+        nodeId,
+        userId: socket.userId,
+        userEmail: socket.userEmail
+      });
+    });
+
+    // Node deselection
+    socket.on('node:deselect', (data) => {
+      const { boardId, nodeId } = data;
+
+      broadcastToBoard(socket, boardId, 'node:deselected', {
+        nodeId,
+        userId: socket.userId
+      });
+    });
+
+    // Board metadata updated (name, description, etc.)
+    socket.on('board:update', async (data) => {
+      const { boardId, patch } = data;
+
+      try {
+        const updatedBoard = await designBoardsAdapter.updateBoard(boardId, patch);
+
+        if (!updatedBoard) {
+          socket.emit('error', { message: 'Board not found' });
+          return;
+        }
+
+        // Log event
+        await designBoardsAdapter.logEvent({
+          boardId,
+          userId: socket.userId,
+          eventType: 'board_updated',
+          payload: { changes: Object.keys(patch) }
+        });
+
+        // Broadcast to all
+        namespace.to(`board:${boardId}`).emit('board:updated', {
+          board: updatedBoard,
+          userId: socket.userId
+        });
+      } catch (error) {
+        console.error('[Design Boards] Error updating board:', error);
+        socket.emit('error', { message: 'Failed to update board' });
+      }
+    });
+
+    // Handle disconnect
+    socket.on('disconnect', () => {
+      console.log(`[Design Boards] User disconnected: ${socket.userId}`);
+
+      // Clean up all board sessions this user was part of
+      for (const [boardId, session] of boardSessions.entries()) {
+        if (session.has(socket.id)) {
+          session.delete(socket.id);
+
+          // Notify others in the room
+          namespace.to(`board:${boardId}`).emit('board:user-left', {
+            userId: socket.userId
+          });
+
+          // Clean up empty sessions
+          if (session.size === 0) {
+            boardSessions.delete(boardId);
+          }
+        }
+      }
+    });
+  });
+
+  // Export helper for external notifications (e.g., from REST API)
+  return {
+    notifyBoardUpdate: (boardId, event, data) => {
+      namespace.to(`board:${boardId}`).emit(event, data);
+    },
+    getBoardUsers
+  };
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ const { Component: Tools } = lazyLoadWithRetry(() => import('./pages/Tools'));
 const { Component: ToolsMetMap } = lazyLoadWithRetry(() => import('./pages/ToolsMetMap'));
 const { Component: ToolsFiles } = lazyLoadWithRetry(() => import('./pages/ToolsFiles'));
 const { Component: ToolsAssets } = lazyLoadWithRetry(() => import('./pages/ToolsAssets'));
+const { Component: DesignBoardPage } = lazyLoadWithRetry(() => import('./pages/DesignBoardPage'));
 
 // Lazy load non-critical pages and components
 const { Component: Home } = lazyLoadWithRetry(() => import('./pages/Home'));
@@ -132,6 +133,7 @@ function AuthenticatedRoutes() {
                   <Route path="/assets" element={<Assets />} />
                   <Route path="/projects" element={<ProjectsNew />} />
                   <Route path="/projects/:id" element={<ProjectDetail />} />
+                  <Route path="/boards/:boardId" element={<DesignBoardPage />} />
                   <Route path="/messages" element={<MessagesNew />} />
                   <Route path="/notifications" element={<Notifications />} />
                   <Route path="/profile" element={<Profile />} />

--- a/src/pages/DesignBoardPage.tsx
+++ b/src/pages/DesignBoardPage.tsx
@@ -1,0 +1,814 @@
+/**
+ * Design Board Page - FluxStudio
+ *
+ * 2D collaborative canvas for placing and editing nodes (text, shapes, assets).
+ * Supports real-time collaboration via Socket.IO.
+ */
+
+import * as React from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { DashboardLayout } from '@/components/templates';
+import { Button, Card } from '@/components/ui';
+import { useAuth } from '../contexts/AuthContext';
+import { useNotification } from '../contexts/NotificationContext';
+import {
+  designBoardsSocketService,
+  BoardNode,
+  Board,
+  BoardUser,
+} from '../services/designBoardsSocketService';
+import {
+  ArrowLeft,
+  Plus,
+  Type,
+  Square,
+  Image,
+  Trash2,
+  Lock,
+  Unlock,
+  ZoomIn,
+  ZoomOut,
+  Move,
+  RotateCw,
+  Layers,
+  Users,
+  Save,
+  MoreHorizontal,
+} from 'lucide-react';
+
+// Node type configurations
+const NODE_TYPES = {
+  text: { label: 'Text', icon: Type, defaultWidth: 200, defaultHeight: 100 },
+  shape: { label: 'Shape', icon: Square, defaultWidth: 100, defaultHeight: 100 },
+  asset: { label: 'Asset', icon: Image, defaultWidth: 200, defaultHeight: 200 },
+};
+
+// Shape types for shape nodes
+const SHAPE_TYPES = ['rectangle', 'circle', 'triangle', 'diamond'];
+
+// Colors for collaborator cursors
+const CURSOR_COLORS = [
+  '#EF4444', '#F97316', '#EAB308', '#22C55E', '#06B6D4', '#3B82F6', '#8B5CF6', '#EC4899'
+];
+
+function getCursorColor(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = ((hash << 5) - hash) + userId.charCodeAt(i);
+    hash |= 0;
+  }
+  return CURSOR_COLORS[Math.abs(hash) % CURSOR_COLORS.length];
+}
+
+// Node component
+function BoardNodeComponent({
+  node,
+  isSelected,
+  isLockedByOther,
+  onSelect,
+  onUpdate,
+  onDelete,
+  scale,
+}: {
+  node: BoardNode;
+  isSelected: boolean;
+  isLockedByOther: boolean;
+  onSelect: (nodeId: string) => void;
+  onUpdate: (nodeId: string, patch: Partial<BoardNode>) => void;
+  onDelete: (nodeId: string) => void;
+  scale: number;
+}) {
+  const [isDragging, setIsDragging] = useState(false);
+  const [isResizing, setIsResizing] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+  const nodeRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (node.locked || isLockedByOther) return;
+    e.stopPropagation();
+    onSelect(node.id);
+
+    const rect = nodeRef.current?.getBoundingClientRect();
+    if (rect) {
+      setDragOffset({
+        x: e.clientX - rect.left,
+        y: e.clientY - rect.top,
+      });
+    }
+    setIsDragging(true);
+  };
+
+  const handleMouseMove = useCallback((e: MouseEvent) => {
+    if (!isDragging || !nodeRef.current) return;
+
+    const canvas = nodeRef.current.parentElement;
+    if (!canvas) return;
+
+    const canvasRect = canvas.getBoundingClientRect();
+    const newX = (e.clientX - canvasRect.left - dragOffset.x) / scale;
+    const newY = (e.clientY - canvasRect.top - dragOffset.y) / scale;
+
+    onUpdate(node.id, { x: Math.max(0, newX), y: Math.max(0, newY) });
+  }, [isDragging, node.id, dragOffset, scale, onUpdate]);
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+    setIsResizing(false);
+  }, []);
+
+  useEffect(() => {
+    if (isDragging || isResizing) {
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+      return () => {
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleMouseUp);
+      };
+    }
+  }, [isDragging, isResizing, handleMouseMove, handleMouseUp]);
+
+  const handleDoubleClick = () => {
+    if (node.type === 'text' && !node.locked && !isLockedByOther) {
+      setIsEditing(true);
+    }
+  };
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    onUpdate(node.id, { data: { ...node.data, content: e.target.value } });
+  };
+
+  const handleTextBlur = () => {
+    setIsEditing(false);
+  };
+
+  const renderNodeContent = () => {
+    switch (node.type) {
+      case 'text':
+        return isEditing ? (
+          <textarea
+            className="w-full h-full p-2 bg-transparent resize-none focus:outline-none"
+            value={(node.data.content as string) || ''}
+            onChange={handleTextChange}
+            onBlur={handleTextBlur}
+            autoFocus
+          />
+        ) : (
+          <div className="p-2 overflow-hidden">
+            {(node.data.content as string) || 'Double-click to edit'}
+          </div>
+        );
+      case 'shape':
+        const shapeType = (node.data.shapeType as string) || 'rectangle';
+        const fillColor = (node.data.fillColor as string) || '#3B82F6';
+        const strokeColor = (node.data.strokeColor as string) || '#1D4ED8';
+
+        if (shapeType === 'circle') {
+          return (
+            <div
+              className="w-full h-full rounded-full"
+              style={{ backgroundColor: fillColor, border: `2px solid ${strokeColor}` }}
+            />
+          );
+        }
+        if (shapeType === 'triangle') {
+          return (
+            <svg viewBox="0 0 100 100" className="w-full h-full">
+              <polygon
+                points="50,5 95,95 5,95"
+                fill={fillColor}
+                stroke={strokeColor}
+                strokeWidth="2"
+              />
+            </svg>
+          );
+        }
+        if (shapeType === 'diamond') {
+          return (
+            <svg viewBox="0 0 100 100" className="w-full h-full">
+              <polygon
+                points="50,5 95,50 50,95 5,50"
+                fill={fillColor}
+                stroke={strokeColor}
+                strokeWidth="2"
+              />
+            </svg>
+          );
+        }
+        return (
+          <div
+            className="w-full h-full rounded"
+            style={{ backgroundColor: fillColor, border: `2px solid ${strokeColor}` }}
+          />
+        );
+      case 'asset':
+        const assetUrl = node.data.previewUrl as string;
+        return assetUrl ? (
+          <img
+            src={assetUrl}
+            alt="Asset"
+            className="w-full h-full object-contain"
+            draggable={false}
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center bg-gray-100 text-gray-400">
+            <Image className="w-8 h-8" />
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div
+      ref={nodeRef}
+      className={`absolute cursor-move select-none ${
+        isSelected ? 'ring-2 ring-primary-500 ring-offset-2' : ''
+      } ${node.locked || isLockedByOther ? 'opacity-75' : ''}`}
+      style={{
+        left: node.x * scale,
+        top: node.y * scale,
+        width: (node.width || 100) * scale,
+        height: (node.height || 100) * scale,
+        zIndex: node.zIndex,
+        transform: `rotate(${node.rotation}deg)`,
+      }}
+      onMouseDown={handleMouseDown}
+      onDoubleClick={handleDoubleClick}
+    >
+      <div className="w-full h-full bg-white border border-gray-200 rounded shadow-sm overflow-hidden">
+        {renderNodeContent()}
+      </div>
+
+      {/* Selection handles */}
+      {isSelected && !node.locked && !isLockedByOther && (
+        <>
+          {/* Resize handles at corners */}
+          <div className="absolute -right-1 -bottom-1 w-3 h-3 bg-primary-500 rounded-sm cursor-se-resize" />
+          <div className="absolute -left-1 -bottom-1 w-3 h-3 bg-primary-500 rounded-sm cursor-sw-resize" />
+          <div className="absolute -right-1 -top-1 w-3 h-3 bg-primary-500 rounded-sm cursor-ne-resize" />
+          <div className="absolute -left-1 -top-1 w-3 h-3 bg-primary-500 rounded-sm cursor-nw-resize" />
+        </>
+      )}
+
+      {/* Lock indicator */}
+      {(node.locked || isLockedByOther) && (
+        <div className="absolute -top-6 left-0 bg-gray-800 text-white text-xs px-1.5 py-0.5 rounded">
+          <Lock className="w-3 h-3 inline" /> {isLockedByOther ? 'In use' : 'Locked'}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Collaborator cursor component
+function CollaboratorCursor({ user }: { user: BoardUser }) {
+  if (!user.cursor) return null;
+
+  const color = getCursorColor(user.userId);
+
+  return (
+    <div
+      className="absolute pointer-events-none z-50 transition-all duration-75"
+      style={{ left: user.cursor.x, top: user.cursor.y }}
+    >
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill={color}
+        className="drop-shadow-md"
+      >
+        <path d="M5.5 3.21V20.8l6.16-6.16h6.96L5.5 3.21z" />
+      </svg>
+      <span
+        className="absolute left-5 top-4 text-xs px-1.5 py-0.5 rounded text-white whitespace-nowrap"
+        style={{ backgroundColor: color }}
+      >
+        {user.userEmail.split('@')[0]}
+      </span>
+    </div>
+  );
+}
+
+// Main page component
+export default function DesignBoardPage() {
+  const { boardId } = useParams<{ boardId: string }>();
+  const navigate = useNavigate();
+  const { user, logout } = useAuth();
+  const { showNotification } = useNotification();
+
+  const [board, setBoard] = useState<Board | null>(null);
+  const [nodes, setNodes] = useState<BoardNode[]>([]);
+  const [collaborators, setCollaborators] = useState<BoardUser[]>([]);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [lockedNodesByOthers, setLockedNodesByOthers] = useState<Map<string, string>>(new Map());
+  const [scale, setScale] = useState(1);
+  const [isConnected, setIsConnected] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const canvasRef = useRef<HTMLDivElement>(null);
+
+  // Auth guard
+  useEffect(() => {
+    if (!user) {
+      navigate('/login', { replace: true });
+    }
+  }, [user, navigate]);
+
+  // Connect to socket and join board
+  useEffect(() => {
+    if (!boardId || !user) return;
+
+    designBoardsSocketService.connect();
+
+    const unsubConnect = designBoardsSocketService.on('connect', () => {
+      setIsConnected(true);
+      designBoardsSocketService.joinBoard(boardId);
+    });
+
+    const unsubDisconnect = designBoardsSocketService.on('disconnect', () => {
+      setIsConnected(false);
+    });
+
+    const unsubJoined = designBoardsSocketService.on('board:joined', (data: unknown) => {
+      const { board: boardData, nodes: nodesData, users } = data as {
+        board: Board;
+        nodes: BoardNode[];
+        users: BoardUser[];
+      };
+      setBoard(boardData);
+      setNodes(nodesData);
+      setCollaborators(users.filter(u => u.userId !== user.id));
+      setIsLoading(false);
+    });
+
+    const unsubUserJoined = designBoardsSocketService.on('board:user-joined', (data: unknown) => {
+      const { userId, userEmail } = data as { userId: string; userEmail: string };
+      if (userId !== user.id) {
+        setCollaborators(prev => [...prev, { userId, userEmail }]);
+        showNotification(`${userEmail.split('@')[0]} joined the board`, 'info');
+      }
+    });
+
+    const unsubUserLeft = designBoardsSocketService.on('board:user-left', (data: unknown) => {
+      const { userId } = data as { userId: string };
+      setCollaborators(prev => prev.filter(u => u.userId !== userId));
+      setLockedNodesByOthers(prev => {
+        const next = new Map(prev);
+        for (const [nodeId, lockUserId] of prev) {
+          if (lockUserId === userId) next.delete(nodeId);
+        }
+        return next;
+      });
+    });
+
+    const unsubCursorMoved = designBoardsSocketService.on('cursor:moved', (data: unknown) => {
+      const { userId, userEmail, x, y } = data as { userId: string; userEmail: string; x: number; y: number };
+      if (userId !== user.id) {
+        setCollaborators(prev =>
+          prev.map(u => u.userId === userId ? { ...u, cursor: { x, y } } : u)
+        );
+      }
+    });
+
+    const unsubNodeCreated = designBoardsSocketService.on('node:created', (data: unknown) => {
+      const { node } = data as { node: BoardNode };
+      setNodes(prev => [...prev, node]);
+    });
+
+    const unsubNodeUpdated = designBoardsSocketService.on('node:updated', (data: unknown) => {
+      const { node } = data as { node: BoardNode };
+      setNodes(prev => prev.map(n => n.id === node.id ? node : n));
+    });
+
+    const unsubNodeDeleted = designBoardsSocketService.on('node:deleted', (data: unknown) => {
+      const { nodeId } = data as { nodeId: string };
+      setNodes(prev => prev.filter(n => n.id !== nodeId));
+      if (selectedNodeId === nodeId) setSelectedNodeId(null);
+    });
+
+    const unsubNodeSelected = designBoardsSocketService.on('node:selected', (data: unknown) => {
+      const { nodeId, userId } = data as { nodeId: string; userId: string };
+      if (userId !== user.id) {
+        setLockedNodesByOthers(prev => new Map(prev).set(nodeId, userId));
+      }
+    });
+
+    const unsubNodeDeselected = designBoardsSocketService.on('node:deselected', (data: unknown) => {
+      const { nodeId, userId } = data as { nodeId: string; userId: string };
+      if (userId !== user.id) {
+        setLockedNodesByOthers(prev => {
+          const next = new Map(prev);
+          next.delete(nodeId);
+          return next;
+        });
+      }
+    });
+
+    return () => {
+      unsubConnect();
+      unsubDisconnect();
+      unsubJoined();
+      unsubUserJoined();
+      unsubUserLeft();
+      unsubCursorMoved();
+      unsubNodeCreated();
+      unsubNodeUpdated();
+      unsubNodeDeleted();
+      unsubNodeSelected();
+      unsubNodeDeselected();
+      if (boardId) designBoardsSocketService.leaveBoard(boardId);
+    };
+  }, [boardId, user, showNotification]);
+
+  // Fetch board via REST if socket not connected
+  useEffect(() => {
+    if (!boardId || !user) return;
+
+    const fetchBoard = async () => {
+      try {
+        const token = localStorage.getItem('auth_token');
+        const response = await fetch(`/api/boards/${boardId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (response.ok) {
+          const data = await response.json();
+          if (data.success) {
+            setBoard(data.board);
+            setNodes(data.nodes);
+            setIsLoading(false);
+          }
+        } else {
+          showNotification('Failed to load board', 'error');
+          navigate(-1);
+        }
+      } catch (error) {
+        console.error('Error fetching board:', error);
+        showNotification('Error loading board', 'error');
+      }
+    };
+
+    // Only fetch via REST if socket hasn't loaded the board yet
+    const timeout = setTimeout(() => {
+      if (isLoading) fetchBoard();
+    }, 2000);
+
+    return () => clearTimeout(timeout);
+  }, [boardId, user, isLoading, navigate, showNotification]);
+
+  // Handle canvas mouse move for cursor tracking
+  const handleCanvasMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!boardId || !canvasRef.current) return;
+
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / scale;
+    const y = (e.clientY - rect.top) / scale;
+
+    // Throttle cursor updates
+    designBoardsSocketService.moveCursor(boardId, x, y);
+  }, [boardId, scale]);
+
+  // Handle canvas click to deselect
+  const handleCanvasClick = () => {
+    if (selectedNodeId && boardId) {
+      designBoardsSocketService.deselectNode(boardId, selectedNodeId);
+    }
+    setSelectedNodeId(null);
+  };
+
+  // Handle node selection
+  const handleSelectNode = useCallback((nodeId: string) => {
+    if (selectedNodeId && boardId) {
+      designBoardsSocketService.deselectNode(boardId, selectedNodeId);
+    }
+    setSelectedNodeId(nodeId);
+    if (boardId) {
+      designBoardsSocketService.selectNode(boardId, nodeId);
+    }
+  }, [selectedNodeId, boardId]);
+
+  // Handle node update
+  const handleUpdateNode = useCallback((nodeId: string, patch: Partial<BoardNode>) => {
+    if (!boardId) return;
+
+    // Optimistic update
+    setNodes(prev => prev.map(n => n.id === nodeId ? { ...n, ...patch } : n));
+
+    // Send to server
+    designBoardsSocketService.updateNode(boardId, nodeId, patch);
+  }, [boardId]);
+
+  // Handle node delete
+  const handleDeleteNode = useCallback((nodeId: string) => {
+    if (!boardId) return;
+
+    setNodes(prev => prev.filter(n => n.id !== nodeId));
+    if (selectedNodeId === nodeId) setSelectedNodeId(null);
+
+    designBoardsSocketService.deleteNode(boardId, nodeId);
+  }, [boardId, selectedNodeId]);
+
+  // Add new node
+  const handleAddNode = (type: 'text' | 'shape' | 'asset') => {
+    if (!boardId) return;
+
+    const config = NODE_TYPES[type];
+    const maxZIndex = nodes.length > 0 ? Math.max(...nodes.map(n => n.zIndex)) : 0;
+
+    const newNode: Partial<BoardNode> = {
+      type,
+      x: 100,
+      y: 100,
+      width: config.defaultWidth,
+      height: config.defaultHeight,
+      zIndex: maxZIndex + 1,
+      rotation: 0,
+      locked: false,
+      data: type === 'text'
+        ? { content: 'New text' }
+        : type === 'shape'
+        ? { shapeType: 'rectangle', fillColor: '#3B82F6', strokeColor: '#1D4ED8' }
+        : {},
+    };
+
+    designBoardsSocketService.createNode(boardId, newNode);
+  };
+
+  // Toggle node lock
+  const handleToggleLock = () => {
+    if (!selectedNodeId || !boardId) return;
+    const node = nodes.find(n => n.id === selectedNodeId);
+    if (node) {
+      handleUpdateNode(selectedNodeId, { locked: !node.locked });
+    }
+  };
+
+  // Zoom controls
+  const handleZoomIn = () => setScale(prev => Math.min(prev + 0.1, 2));
+  const handleZoomOut = () => setScale(prev => Math.max(prev - 0.1, 0.5));
+  const handleZoomReset = () => setScale(1);
+
+  // Back navigation
+  const handleBack = () => {
+    if (board?.projectId) {
+      navigate(`/projects/${board.projectId}`);
+    } else {
+      navigate(-1);
+    }
+  };
+
+  if (!user) return null;
+
+  const selectedNode = selectedNodeId ? nodes.find(n => n.id === selectedNodeId) : null;
+
+  return (
+    <DashboardLayout
+      user={user || undefined}
+      breadcrumbs={[
+        { label: 'Projects', href: '/projects' },
+        { label: board?.name || 'Board' },
+      ]}
+      onLogout={logout}
+    >
+      <div className="h-[calc(100vh-64px)] flex flex-col">
+        {/* Toolbar */}
+        <div className="flex items-center justify-between px-4 py-2 border-b bg-white">
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" size="sm" onClick={handleBack}>
+              <ArrowLeft className="w-4 h-4 mr-1" />
+              Back
+            </Button>
+
+            <div className="h-6 w-px bg-gray-200" />
+
+            <span className="font-medium text-gray-900">{board?.name || 'Loading...'}</span>
+
+            {!isConnected && (
+              <span className="text-xs text-amber-600 bg-amber-50 px-2 py-0.5 rounded">
+                Offline
+              </span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            {/* Collaborators */}
+            {collaborators.length > 0 && (
+              <div className="flex items-center gap-1 mr-2">
+                <Users className="w-4 h-4 text-gray-400" />
+                <span className="text-sm text-gray-600">{collaborators.length}</span>
+              </div>
+            )}
+
+            {/* Add node buttons */}
+            <Button variant="outline" size="sm" onClick={() => handleAddNode('text')}>
+              <Type className="w-4 h-4 mr-1" />
+              Text
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => handleAddNode('shape')}>
+              <Square className="w-4 h-4 mr-1" />
+              Shape
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => handleAddNode('asset')}>
+              <Image className="w-4 h-4 mr-1" />
+              Asset
+            </Button>
+
+            <div className="h-6 w-px bg-gray-200 mx-1" />
+
+            {/* Zoom controls */}
+            <Button variant="ghost" size="sm" onClick={handleZoomOut}>
+              <ZoomOut className="w-4 h-4" />
+            </Button>
+            <span className="text-sm text-gray-600 w-12 text-center">{Math.round(scale * 100)}%</span>
+            <Button variant="ghost" size="sm" onClick={handleZoomIn}>
+              <ZoomIn className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+
+        {/* Main content */}
+        <div className="flex-1 flex">
+          {/* Canvas */}
+          <div
+            ref={canvasRef}
+            className="flex-1 bg-gray-50 overflow-auto relative"
+            onMouseMove={handleCanvasMouseMove}
+            onClick={handleCanvasClick}
+          >
+            {isLoading ? (
+              <div className="flex items-center justify-center h-full">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600" />
+              </div>
+            ) : (
+              <div
+                className="relative min-w-[2000px] min-h-[2000px]"
+                style={{
+                  backgroundImage: 'radial-gradient(circle, #d1d5db 1px, transparent 1px)',
+                  backgroundSize: `${20 * scale}px ${20 * scale}px`,
+                }}
+              >
+                {/* Nodes */}
+                {nodes.map(node => (
+                  <BoardNodeComponent
+                    key={node.id}
+                    node={node}
+                    isSelected={selectedNodeId === node.id}
+                    isLockedByOther={lockedNodesByOthers.has(node.id)}
+                    onSelect={handleSelectNode}
+                    onUpdate={handleUpdateNode}
+                    onDelete={handleDeleteNode}
+                    scale={scale}
+                  />
+                ))}
+
+                {/* Collaborator cursors */}
+                {collaborators.map(user => (
+                  <CollaboratorCursor key={user.userId} user={user} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Properties panel */}
+          {selectedNode && (
+            <div className="w-64 border-l bg-white p-4">
+              <h3 className="font-medium text-gray-900 mb-4">Properties</h3>
+
+              <div className="space-y-4">
+                <div>
+                  <label className="text-xs text-gray-500 uppercase">Type</label>
+                  <p className="text-sm font-medium capitalize">{selectedNode.type}</p>
+                </div>
+
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="text-xs text-gray-500 uppercase">X</label>
+                    <input
+                      type="number"
+                      value={Math.round(selectedNode.x)}
+                      onChange={(e) => handleUpdateNode(selectedNode.id, { x: parseInt(e.target.value) || 0 })}
+                      className="w-full px-2 py-1 text-sm border rounded"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-xs text-gray-500 uppercase">Y</label>
+                    <input
+                      type="number"
+                      value={Math.round(selectedNode.y)}
+                      onChange={(e) => handleUpdateNode(selectedNode.id, { y: parseInt(e.target.value) || 0 })}
+                      className="w-full px-2 py-1 text-sm border rounded"
+                    />
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-2">
+                  <div>
+                    <label className="text-xs text-gray-500 uppercase">Width</label>
+                    <input
+                      type="number"
+                      value={Math.round(selectedNode.width || 100)}
+                      onChange={(e) => handleUpdateNode(selectedNode.id, { width: parseInt(e.target.value) || 100 })}
+                      className="w-full px-2 py-1 text-sm border rounded"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-xs text-gray-500 uppercase">Height</label>
+                    <input
+                      type="number"
+                      value={Math.round(selectedNode.height || 100)}
+                      onChange={(e) => handleUpdateNode(selectedNode.id, { height: parseInt(e.target.value) || 100 })}
+                      className="w-full px-2 py-1 text-sm border rounded"
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="text-xs text-gray-500 uppercase">Rotation</label>
+                  <input
+                    type="number"
+                    value={selectedNode.rotation}
+                    onChange={(e) => handleUpdateNode(selectedNode.id, { rotation: parseInt(e.target.value) || 0 })}
+                    className="w-full px-2 py-1 text-sm border rounded"
+                  />
+                </div>
+
+                <div>
+                  <label className="text-xs text-gray-500 uppercase">Layer</label>
+                  <input
+                    type="number"
+                    value={selectedNode.zIndex}
+                    onChange={(e) => handleUpdateNode(selectedNode.id, { zIndex: parseInt(e.target.value) || 0 })}
+                    className="w-full px-2 py-1 text-sm border rounded"
+                  />
+                </div>
+
+                {selectedNode.type === 'shape' && (
+                  <>
+                    <div>
+                      <label className="text-xs text-gray-500 uppercase">Shape</label>
+                      <select
+                        value={(selectedNode.data.shapeType as string) || 'rectangle'}
+                        onChange={(e) => handleUpdateNode(selectedNode.id, {
+                          data: { ...selectedNode.data, shapeType: e.target.value }
+                        })}
+                        className="w-full px-2 py-1 text-sm border rounded"
+                      >
+                        {SHAPE_TYPES.map(s => (
+                          <option key={s} value={s}>{s}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className="text-xs text-gray-500 uppercase">Fill Color</label>
+                      <input
+                        type="color"
+                        value={(selectedNode.data.fillColor as string) || '#3B82F6'}
+                        onChange={(e) => handleUpdateNode(selectedNode.id, {
+                          data: { ...selectedNode.data, fillColor: e.target.value }
+                        })}
+                        className="w-full h-8 border rounded cursor-pointer"
+                      />
+                    </div>
+                  </>
+                )}
+
+                <div className="flex gap-2 pt-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleToggleLock}
+                    className="flex-1"
+                  >
+                    {selectedNode.locked ? (
+                      <>
+                        <Unlock className="w-4 h-4 mr-1" />
+                        Unlock
+                      </>
+                    ) : (
+                      <>
+                        <Lock className="w-4 h-4 mr-1" />
+                        Lock
+                      </>
+                    )}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleDeleteNode(selectedNode.id)}
+                    className="text-red-600 hover:bg-red-50"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/services/designBoardsSocketService.ts
+++ b/src/services/designBoardsSocketService.ts
@@ -1,0 +1,237 @@
+/**
+ * Design Boards Socket Service
+ * Handles real-time collaboration for design boards
+ */
+
+import { io, Socket } from 'socket.io-client';
+
+export interface BoardNode {
+  id: string;
+  boardId: string;
+  type: 'text' | 'asset' | 'shape';
+  assetId?: string;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+  zIndex: number;
+  rotation: number;
+  locked: boolean;
+  data: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Board {
+  id: string;
+  projectId: string;
+  organizationId?: string;
+  ownerId: string;
+  name: string;
+  description?: string;
+  thumbnailAssetId?: string;
+  isArchived: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BoardUser {
+  userId: string;
+  userEmail: string;
+  cursor?: { x: number; y: number };
+}
+
+type EventCallback = (...args: unknown[]) => void;
+
+class DesignBoardsSocketService {
+  private socket: Socket | null = null;
+  private eventListeners: Map<string, Set<EventCallback>> = new Map();
+  private isConnected = false;
+  private currentBoardId: string | null = null;
+
+  connect(): void {
+    const token = localStorage.getItem('auth_token');
+    if (!token) {
+      console.warn('[DesignBoardsSocket] No auth token, skipping connection');
+      return;
+    }
+
+    if (this.socket?.connected) {
+      return;
+    }
+
+    const socketUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
+
+    this.socket = io(`${socketUrl}/design-boards`, {
+      path: '/api/socket.io',
+      auth: { token },
+      transports: ['websocket', 'polling'],
+      reconnection: true,
+      reconnectionAttempts: 5,
+      reconnectionDelay: 1000,
+    });
+
+    this.setupEventHandlers();
+  }
+
+  private setupEventHandlers(): void {
+    if (!this.socket) return;
+
+    this.socket.on('connect', () => {
+      console.log('[DesignBoardsSocket] Connected');
+      this.isConnected = true;
+      this.emit('connect');
+    });
+
+    this.socket.on('disconnect', (reason: string) => {
+      console.log('[DesignBoardsSocket] Disconnected:', reason);
+      this.isConnected = false;
+      this.emit('disconnect');
+    });
+
+    this.socket.on('error', (error: { message: string }) => {
+      console.error('[DesignBoardsSocket] Error:', error);
+      this.emit('error', error);
+    });
+
+    // Board events
+    this.socket.on('board:joined', (data: { board: Board; nodes: BoardNode[]; users: BoardUser[] }) => {
+      this.emit('board:joined', data);
+    });
+
+    this.socket.on('board:user-joined', (data: { userId: string; userEmail: string }) => {
+      this.emit('board:user-joined', data);
+    });
+
+    this.socket.on('board:user-left', (data: { userId: string }) => {
+      this.emit('board:user-left', data);
+    });
+
+    this.socket.on('board:updated', (data: { board: Board; userId: string }) => {
+      this.emit('board:updated', data);
+    });
+
+    // Node events
+    this.socket.on('node:created', (data: { node: BoardNode; userId: string }) => {
+      this.emit('node:created', data);
+    });
+
+    this.socket.on('node:updated', (data: { node: BoardNode; userId: string }) => {
+      this.emit('node:updated', data);
+    });
+
+    this.socket.on('node:deleted', (data: { nodeId: string; userId: string }) => {
+      this.emit('node:deleted', data);
+    });
+
+    this.socket.on('nodes:bulk-updated', (data: { nodes: BoardNode[]; userId: string }) => {
+      this.emit('nodes:bulk-updated', data);
+    });
+
+    // Cursor events
+    this.socket.on('cursor:moved', (data: { userId: string; userEmail: string; x: number; y: number }) => {
+      this.emit('cursor:moved', data);
+    });
+
+    // Selection events
+    this.socket.on('node:selected', (data: { nodeId: string; userId: string; userEmail: string }) => {
+      this.emit('node:selected', data);
+    });
+
+    this.socket.on('node:deselected', (data: { nodeId: string; userId: string }) => {
+      this.emit('node:deselected', data);
+    });
+  }
+
+  disconnect(): void {
+    if (this.currentBoardId) {
+      this.leaveBoard(this.currentBoardId);
+    }
+    this.socket?.disconnect();
+    this.socket = null;
+    this.isConnected = false;
+  }
+
+  // Board actions
+  joinBoard(boardId: string): void {
+    if (!this.socket?.connected) {
+      console.warn('[DesignBoardsSocket] Not connected');
+      return;
+    }
+    this.currentBoardId = boardId;
+    this.socket.emit('board:join', boardId);
+  }
+
+  leaveBoard(boardId: string): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('board:leave', boardId);
+    if (this.currentBoardId === boardId) {
+      this.currentBoardId = null;
+    }
+  }
+
+  updateBoard(boardId: string, patch: Partial<Board>): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('board:update', { boardId, patch });
+  }
+
+  // Node actions
+  createNode(boardId: string, node: Partial<BoardNode>): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('node:create', { boardId, node });
+  }
+
+  updateNode(boardId: string, nodeId: string, patch: Partial<BoardNode>): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('node:update', { boardId, nodeId, patch });
+  }
+
+  deleteNode(boardId: string, nodeId: string): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('node:delete', { boardId, nodeId });
+  }
+
+  bulkUpdateNodePositions(boardId: string, updates: Array<{ nodeId: string; x?: number; y?: number; zIndex?: number }>): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('nodes:bulk-position', { boardId, updates });
+  }
+
+  // Cursor position
+  moveCursor(boardId: string, x: number, y: number): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('cursor:move', { boardId, x, y });
+  }
+
+  // Selection
+  selectNode(boardId: string, nodeId: string): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('node:select', { boardId, nodeId });
+  }
+
+  deselectNode(boardId: string, nodeId: string): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('node:deselect', { boardId, nodeId });
+  }
+
+  // Event handling
+  on(event: string, callback: EventCallback): () => void {
+    if (!this.eventListeners.has(event)) {
+      this.eventListeners.set(event, new Set());
+    }
+    this.eventListeners.get(event)!.add(callback);
+
+    return () => {
+      this.eventListeners.get(event)?.delete(callback);
+    };
+  }
+
+  private emit(event: string, ...args: unknown[]): void {
+    this.eventListeners.get(event)?.forEach(callback => callback(...args));
+  }
+
+  getConnectionStatus(): boolean {
+    return this.isConnected && this.socket?.connected === true;
+  }
+}
+
+export const designBoardsSocketService = new DesignBoardsSocketService();


### PR DESCRIPTION
- Add migration 036 for design_boards, design_board_nodes, and design_board_events tables
- Create design-boards-adapter.js with full CRUD operations for boards and nodes
- Add REST API endpoints under /api/projects/:projectId/boards and /api/boards/:boardId
- Implement Socket.IO namespace /design-boards for real-time collaboration with cursor tracking, node updates, and presence
- Create DesignBoardPage.tsx with canvas, node editing, properties panel, and collaborator cursors
- Add Boards tab to ProjectDetail page with board listing and creation
- Register /boards/:boardId route in App.tsx