### PR TITLE
feat(messaging): Add WebSocket wiring for real-time conversations

### DIFF
--- a/src/hooks/useConversationRealtime.ts
+++ b/src/hooks/useConversationRealtime.ts
@@ -1,0 +1,340 @@
+/**
+ * useConversationRealtime Hook
+ *
+ * Provides real-time updates for conversation-based messaging using the new
+ * conversation socket events. This hook integrates with messagingSocketService
+ * to provide live message updates, typing indicators, and read receipts.
+ */
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import {
+  messagingSocketService,
+  ConversationMessage,
+  Conversation,
+  Notification,
+} from '../services/messagingSocketService';
+
+interface TypingUser {
+  userId: string;
+  userEmail: string;
+  conversationId: string;
+}
+
+interface ReadReceipt {
+  conversationId: string;
+  userId: string;
+  messageId: string;
+}
+
+interface UseConversationRealtimeOptions {
+  conversationId?: string;
+  autoConnect?: boolean;
+  onNewMessage?: (data: { conversationId: string; message: ConversationMessage }) => void;
+  onMessageDeleted?: (data: { conversationId: string; messageId: string }) => void;
+  onTypingStart?: (data: TypingUser) => void;
+  onTypingStop?: (data: { conversationId: string; userId: string }) => void;
+  onReadReceipt?: (data: ReadReceipt) => void;
+  onNotification?: (notification: Notification) => void;
+}
+
+interface UseConversationRealtimeReturn {
+  // Connection state
+  isConnected: boolean;
+
+  // Real-time data
+  messages: ConversationMessage[];
+  typingUsers: TypingUser[];
+  unreadCount: number;
+
+  // Actions
+  connect: () => void;
+  disconnect: () => void;
+  joinConversation: (conversationId: string) => void;
+  leaveConversation: (conversationId: string) => void;
+  sendMessage: (text: string, options?: { replyToMessageId?: string; assetId?: string; projectId?: string }) => void;
+  deleteMessage: (messageId: string) => void;
+  startTyping: () => void;
+  stopTyping: () => void;
+  markAsRead: (messageId: string) => void;
+  subscribeToNotifications: () => void;
+  markNotificationRead: (notificationId: string) => void;
+  markAllNotificationsRead: () => void;
+}
+
+export function useConversationRealtime(options: UseConversationRealtimeOptions = {}): UseConversationRealtimeReturn {
+  const { user } = useAuth();
+  const {
+    conversationId,
+    autoConnect = true,
+    onNewMessage,
+    onMessageDeleted,
+    onTypingStart,
+    onTypingStop,
+    onReadReceipt,
+    onNotification,
+  } = options;
+
+  const [isConnected, setIsConnected] = useState(false);
+  const [messages, setMessages] = useState<ConversationMessage[]>([]);
+  const [typingUsers, setTypingUsers] = useState<TypingUser[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  const currentConversationId = useRef<string | null>(null);
+  const typingTimeouts = useRef<Map<string, NodeJS.Timeout>>(new Map());
+
+  // Connect to socket
+  const connect = useCallback(() => {
+    if (!user) return;
+    messagingSocketService.connect();
+  }, [user]);
+
+  // Disconnect from socket
+  const disconnect = useCallback(() => {
+    messagingSocketService.disconnect();
+    setIsConnected(false);
+  }, []);
+
+  // Join a conversation room
+  const joinConversation = useCallback((convId: string) => {
+    if (currentConversationId.current && currentConversationId.current !== convId) {
+      messagingSocketService.leaveConversation(currentConversationId.current);
+    }
+    currentConversationId.current = convId;
+    messagingSocketService.joinConversation(convId);
+  }, []);
+
+  // Leave a conversation room
+  const leaveConversation = useCallback((convId: string) => {
+    messagingSocketService.leaveConversation(convId);
+    if (currentConversationId.current === convId) {
+      currentConversationId.current = null;
+    }
+  }, []);
+
+  // Send a message
+  const sendMessage = useCallback((text: string, msgOptions?: { replyToMessageId?: string; assetId?: string; projectId?: string }) => {
+    if (!currentConversationId.current) return;
+    messagingSocketService.sendMessage({
+      conversationId: currentConversationId.current,
+      text,
+      ...msgOptions,
+    });
+  }, []);
+
+  // Delete a message
+  const deleteMessage = useCallback((messageId: string) => {
+    if (!currentConversationId.current) return;
+    messagingSocketService.deleteMessage(currentConversationId.current, messageId);
+  }, []);
+
+  // Start typing indicator
+  const startTyping = useCallback(() => {
+    if (!currentConversationId.current) return;
+    messagingSocketService.startTyping(currentConversationId.current);
+  }, []);
+
+  // Stop typing indicator
+  const stopTyping = useCallback(() => {
+    if (!currentConversationId.current) return;
+    messagingSocketService.stopTyping(currentConversationId.current);
+  }, []);
+
+  // Mark conversation as read
+  const markAsRead = useCallback((messageId: string) => {
+    if (!currentConversationId.current) return;
+    messagingSocketService.markAsRead(currentConversationId.current, messageId);
+  }, []);
+
+  // Subscribe to notifications
+  const subscribeToNotifications = useCallback(() => {
+    messagingSocketService.subscribeToNotifications();
+  }, []);
+
+  // Mark notification as read
+  const markNotificationRead = useCallback((notificationId: string) => {
+    messagingSocketService.markNotificationRead(notificationId);
+  }, []);
+
+  // Mark all notifications as read
+  const markAllNotificationsRead = useCallback(() => {
+    messagingSocketService.markAllNotificationsRead();
+  }, []);
+
+  // Set up event listeners
+  useEffect(() => {
+    const unsubscribers: Array<() => void> = [];
+
+    // Connection events
+    unsubscribers.push(
+      messagingSocketService.on('connect', () => {
+        setIsConnected(true);
+        // Auto-join conversation if provided
+        if (conversationId) {
+          joinConversation(conversationId);
+        }
+        // Auto-subscribe to notifications
+        subscribeToNotifications();
+      })
+    );
+
+    unsubscribers.push(
+      messagingSocketService.on('disconnect', () => {
+        setIsConnected(false);
+      })
+    );
+
+    // Initial messages on conversation join
+    unsubscribers.push(
+      messagingSocketService.on('conversation:messages', (data: unknown) => {
+        const { messages: initialMessages } = data as { conversationId: string; messages: ConversationMessage[]; hasMore: boolean };
+        setMessages(initialMessages);
+      })
+    );
+
+    // New message
+    unsubscribers.push(
+      messagingSocketService.on('conversation:message:new', (data: unknown) => {
+        const typedData = data as { conversationId: string; message: ConversationMessage };
+        setMessages(prev => [...prev, typedData.message]);
+        onNewMessage?.(typedData);
+      })
+    );
+
+    // Message notification (for other conversations)
+    unsubscribers.push(
+      messagingSocketService.on('conversation:message:notify', (data: unknown) => {
+        const typedData = data as { conversationId: string; message: ConversationMessage; senderEmail: string };
+        // Could show a toast notification here
+        console.log(`[Realtime] New message in ${typedData.conversationId} from ${typedData.senderEmail}`);
+      })
+    );
+
+    // Message deleted
+    unsubscribers.push(
+      messagingSocketService.on('conversation:message:deleted', (data: unknown) => {
+        const typedData = data as { conversationId: string; messageId: string; deletedBy: string };
+        setMessages(prev => prev.filter(m => m.id !== typedData.messageId));
+        onMessageDeleted?.(typedData);
+      })
+    );
+
+    // Typing indicators
+    unsubscribers.push(
+      messagingSocketService.on('conversation:user-typing', (data: unknown) => {
+        const typedData = data as { conversationId: string; userId: string; userEmail: string };
+        setTypingUsers(prev => {
+          if (prev.some(u => u.userId === typedData.userId)) return prev;
+          return [...prev, typedData];
+        });
+        onTypingStart?.(typedData);
+
+        // Auto-remove after 3 seconds if no stop event
+        const timeoutKey = `${typedData.conversationId}:${typedData.userId}`;
+        const existingTimeout = typingTimeouts.current.get(timeoutKey);
+        if (existingTimeout) clearTimeout(existingTimeout);
+
+        typingTimeouts.current.set(timeoutKey, setTimeout(() => {
+          setTypingUsers(prev => prev.filter(u => u.userId !== typedData.userId));
+          typingTimeouts.current.delete(timeoutKey);
+        }, 3000));
+      })
+    );
+
+    unsubscribers.push(
+      messagingSocketService.on('conversation:user-stopped-typing', (data: unknown) => {
+        const typedData = data as { conversationId: string; userId: string };
+        setTypingUsers(prev => prev.filter(u => u.userId !== typedData.userId));
+        onTypingStop?.(typedData);
+
+        // Clear timeout
+        const timeoutKey = `${typedData.conversationId}:${typedData.userId}`;
+        const existingTimeout = typingTimeouts.current.get(timeoutKey);
+        if (existingTimeout) {
+          clearTimeout(existingTimeout);
+          typingTimeouts.current.delete(timeoutKey);
+        }
+      })
+    );
+
+    // Read receipts
+    unsubscribers.push(
+      messagingSocketService.on('conversation:read-receipt', (data: unknown) => {
+        const typedData = data as { conversationId: string; userId: string; messageId: string };
+        onReadReceipt?.(typedData);
+      })
+    );
+
+    // Notifications
+    unsubscribers.push(
+      messagingSocketService.on('notification:new', (notification: unknown) => {
+        onNotification?.(notification as Notification);
+      })
+    );
+
+    unsubscribers.push(
+      messagingSocketService.on('notifications:unread-count', (data: unknown) => {
+        const typedData = data as { count: number };
+        setUnreadCount(typedData.count);
+      })
+    );
+
+    // Auto-connect if enabled
+    if (autoConnect && user) {
+      connect();
+    }
+
+    // Cleanup
+    return () => {
+      unsubscribers.forEach(unsub => unsub());
+      typingTimeouts.current.forEach(timeout => clearTimeout(timeout));
+      typingTimeouts.current.clear();
+    };
+  }, [
+    user,
+    autoConnect,
+    conversationId,
+    connect,
+    joinConversation,
+    subscribeToNotifications,
+    onNewMessage,
+    onMessageDeleted,
+    onTypingStart,
+    onTypingStop,
+    onReadReceipt,
+    onNotification,
+  ]);
+
+  // Handle conversation ID changes
+  useEffect(() => {
+    if (isConnected && conversationId) {
+      joinConversation(conversationId);
+    }
+  }, [isConnected, conversationId, joinConversation]);
+
+  return {
+    // Connection state
+    isConnected,
+
+    // Real-time data
+    messages,
+    typingUsers,
+    unreadCount,
+
+    // Actions
+    connect,
+    disconnect,
+    joinConversation,
+    leaveConversation,
+    sendMessage,
+    deleteMessage,
+    startTyping,
+    stopTyping,
+    markAsRead,
+    subscribeToNotifications,
+    markNotificationRead,
+    markAllNotificationsRead,
+  };
+}
+
+export default useConversationRealtime;

--- a/src/services/messagingSocketService.ts
+++ b/src/services/messagingSocketService.ts
@@ -1,0 +1,304 @@
+/**
+ * Messaging Socket Service
+ * Handles real-time messaging for conversations using the new conversation-based events
+ */
+
+import { io, Socket } from 'socket.io-client';
+
+export interface ConversationMessage {
+  id: string;
+  conversationId: string;
+  authorId: string;
+  content: string;
+  replyToMessageId?: string;
+  assetId?: string;
+  projectId?: string;
+  isSystemMessage: boolean;
+  createdAt: string;
+  updatedAt: string;
+  author?: {
+    id: string;
+    email: string;
+    displayName?: string;
+  };
+}
+
+export interface Conversation {
+  id: string;
+  organizationId?: string;
+  name?: string;
+  isGroup: boolean;
+  createdAt: string;
+  updatedAt: string;
+  members?: ConversationMember[];
+  lastMessage?: ConversationMessage;
+  unreadCount?: number;
+}
+
+export interface ConversationMember {
+  id: string;
+  conversationId: string;
+  userId: string;
+  role: string;
+  lastReadMessageId?: string;
+  createdAt: string;
+  user?: {
+    id: string;
+    email: string;
+    displayName?: string;
+  };
+}
+
+export interface Notification {
+  id: string;
+  userId: string;
+  type: string;
+  entityId?: string;
+  title: string;
+  body?: string;
+  isRead: boolean;
+  createdAt: string;
+}
+
+type EventCallback = (...args: unknown[]) => void;
+
+class MessagingSocketService {
+  private socket: Socket | null = null;
+  private eventListeners: Map<string, Set<EventCallback>> = new Map();
+  private isConnected = false;
+  private currentConversationId: string | null = null;
+
+  connect(): void {
+    const token = localStorage.getItem('auth_token');
+    if (!token) {
+      console.warn('[MessagingSocket] No auth token, skipping connection');
+      return;
+    }
+
+    if (this.socket?.connected) {
+      return;
+    }
+
+    const isDevelopment = window.location.hostname === 'localhost';
+    const socketUrl = isDevelopment ? 'http://localhost:3001' : window.location.origin;
+
+    this.socket = io(`${socketUrl}/messaging`, {
+      path: '/api/socket.io',
+      auth: { token },
+      transports: ['websocket', 'polling'],
+      reconnection: true,
+      reconnectionAttempts: 5,
+      reconnectionDelay: 1000,
+    });
+
+    this.setupEventHandlers();
+  }
+
+  private setupEventHandlers(): void {
+    if (!this.socket) return;
+
+    this.socket.on('connect', () => {
+      console.log('[MessagingSocket] Connected');
+      this.isConnected = true;
+      this.emit('connect');
+    });
+
+    this.socket.on('disconnect', (reason: string) => {
+      console.log('[MessagingSocket] Disconnected:', reason);
+      this.isConnected = false;
+      this.emit('disconnect');
+    });
+
+    this.socket.on('error', (error: { message: string }) => {
+      console.error('[MessagingSocket] Error:', error);
+      this.emit('error', error);
+    });
+
+    // User status events
+    this.socket.on('user:status', (data: { userId: string; status: string }) => {
+      this.emit('user:status', data);
+    });
+
+    // Conversation events
+    this.socket.on('conversation:messages', (data: { conversationId: string; messages: ConversationMessage[]; hasMore: boolean }) => {
+      this.emit('conversation:messages', data);
+    });
+
+    this.socket.on('conversation:user-joined', (data: { conversationId: string; userId: string; userEmail: string }) => {
+      this.emit('conversation:user-joined', data);
+    });
+
+    this.socket.on('conversation:user-left', (data: { conversationId: string; userId: string }) => {
+      this.emit('conversation:user-left', data);
+    });
+
+    // Message events
+    this.socket.on('conversation:message:new', (data: { conversationId: string; message: ConversationMessage }) => {
+      this.emit('conversation:message:new', data);
+    });
+
+    this.socket.on('conversation:message:notify', (data: { conversationId: string; message: ConversationMessage; senderEmail: string }) => {
+      this.emit('conversation:message:notify', data);
+    });
+
+    this.socket.on('conversation:message:deleted', (data: { conversationId: string; messageId: string; deletedBy: string }) => {
+      this.emit('conversation:message:deleted', data);
+    });
+
+    // Typing events
+    this.socket.on('conversation:user-typing', (data: { conversationId: string; userId: string; userEmail: string }) => {
+      this.emit('conversation:user-typing', data);
+    });
+
+    this.socket.on('conversation:user-stopped-typing', (data: { conversationId: string; userId: string }) => {
+      this.emit('conversation:user-stopped-typing', data);
+    });
+
+    // Read receipt events
+    this.socket.on('conversation:read-receipt', (data: { conversationId: string; userId: string; messageId: string }) => {
+      this.emit('conversation:read-receipt', data);
+    });
+
+    this.socket.on('conversation:read:confirmed', (data: { conversationId: string; messageId: string }) => {
+      this.emit('conversation:read:confirmed', data);
+    });
+
+    // Notification events
+    this.socket.on('notification:new', (notification: Notification) => {
+      this.emit('notification:new', notification);
+    });
+
+    this.socket.on('notification:updated', (notification: Notification) => {
+      this.emit('notification:updated', notification);
+    });
+
+    this.socket.on('notifications:unread-count', (data: { count: number }) => {
+      this.emit('notifications:unread-count', data);
+    });
+
+    this.socket.on('notifications:all-marked-read', () => {
+      this.emit('notifications:all-marked-read');
+    });
+  }
+
+  disconnect(): void {
+    if (this.currentConversationId) {
+      this.leaveConversation(this.currentConversationId);
+    }
+    this.socket?.disconnect();
+    this.socket = null;
+    this.isConnected = false;
+  }
+
+  // ========================================
+  // CONVERSATION ACTIONS
+  // ========================================
+
+  joinConversation(conversationId: string): void {
+    if (!this.socket?.connected) {
+      console.warn('[MessagingSocket] Not connected');
+      return;
+    }
+    this.currentConversationId = conversationId;
+    this.socket.emit('conversation:join', conversationId);
+  }
+
+  leaveConversation(conversationId: string): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('conversation:leave', conversationId);
+    if (this.currentConversationId === conversationId) {
+      this.currentConversationId = null;
+    }
+  }
+
+  // ========================================
+  // MESSAGE ACTIONS
+  // ========================================
+
+  sendMessage(data: {
+    conversationId: string;
+    text: string;
+    replyToMessageId?: string;
+    assetId?: string;
+    projectId?: string;
+  }): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('conversation:message:send', data);
+  }
+
+  deleteMessage(conversationId: string, messageId: string): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('conversation:message:delete', { conversationId, messageId });
+  }
+
+  // ========================================
+  // TYPING INDICATORS
+  // ========================================
+
+  startTyping(conversationId: string): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('conversation:typing:start', conversationId);
+  }
+
+  stopTyping(conversationId: string): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('conversation:typing:stop', conversationId);
+  }
+
+  // ========================================
+  // READ RECEIPTS
+  // ========================================
+
+  markAsRead(conversationId: string, messageId: string): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('conversation:read', { conversationId, messageId });
+  }
+
+  // ========================================
+  // NOTIFICATIONS
+  // ========================================
+
+  subscribeToNotifications(): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('notifications:subscribe');
+  }
+
+  markNotificationRead(notificationId: string): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('notification:mark-read', notificationId);
+  }
+
+  markAllNotificationsRead(): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('notifications:mark-all-read');
+  }
+
+  // ========================================
+  // EVENT HANDLING
+  // ========================================
+
+  on(event: string, callback: EventCallback): () => void {
+    if (!this.eventListeners.has(event)) {
+      this.eventListeners.set(event, new Set());
+    }
+    this.eventListeners.get(event)!.add(callback);
+
+    return () => {
+      this.eventListeners.get(event)?.delete(callback);
+    };
+  }
+
+  private emit(event: string, ...args: unknown[]): void {
+    this.eventListeners.get(event)?.forEach(callback => callback(...args));
+  }
+
+  getConnectionStatus(): boolean {
+    return this.isConnected && this.socket?.connected === true;
+  }
+
+  getCurrentConversationId(): string | null {
+    return this.currentConversationId;
+  }
+}
+
+export const messagingSocketService = new MessagingSocketService();


### PR DESCRIPTION
- Refactor sockets/messaging-socket.js to use messagingConversationsAdapter
- Add new conversation-based socket events (conversation:join, conversation:leave, conversation:message:send, conversation:typing:*, conversation:read, etc.)
- Maintain backward compatibility with existing channel-based events
- Add helper methods for sending notifications and broadcasting to conversations
- Create frontend messagingSocketService.ts for real-time conversation updates
- Create useConversationRealtime hook for React components integration
- Add typing indicators with auto-timeout
- Add read receipt support
- Add notification subscription support