### PR TITLE
feat(messaging): Add inline message editing with real-time sync

### DIFF
--- a/src/components/messaging/MessageActionsMenu.tsx
+++ b/src/components/messaging/MessageActionsMenu.tsx
@@ -12,6 +12,7 @@ import {
   Copy,
   Trash2,
   MoreHorizontal,
+  Pencil,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -27,11 +28,13 @@ export interface MessageActionsMenuProps {
   canReply?: boolean;
   canReact?: boolean;
   canPin?: boolean;
+  canEdit?: boolean;
   canDelete?: boolean;
   isPinned?: boolean;
   onReply?: (messageId: string) => void;
   onReact?: (messageId: string) => void;
   onPinToggle?: (messageId: string) => void;
+  onEdit?: (messageId: string) => void;
   onCopy?: (messageId: string) => void;
   onDelete?: (messageId: string) => void;
   className?: string;
@@ -45,11 +48,13 @@ export function MessageActionsMenu({
   canReply = true,
   canReact = true,
   canPin = true,
+  canEdit = false,
   canDelete = false,
   isPinned = false,
   onReply,
   onReact,
   onPinToggle,
+  onEdit,
   onCopy,
   onDelete,
   className,
@@ -104,6 +109,14 @@ export function MessageActionsMenu({
                 Pin message
               </>
             )}
+          </DropdownMenuItem>
+        )}
+
+        {/* Edit */}
+        {canEdit && onEdit && (
+          <DropdownMenuItem onClick={() => onEdit(messageId)}>
+            <Pencil className="w-4 h-4 mr-2" />
+            Edit message
           </DropdownMenuItem>
         )}
 

--- a/src/services/messagingSocketService.ts
+++ b/src/services/messagingSocketService.ts
@@ -22,6 +22,7 @@ export interface ConversationMessage {
   isSystemMessage: boolean;
   createdAt: string;
   updatedAt: string;
+  editedAt?: string;
   reactions?: MessageReactionSummary[];
   author?: {
     id: string;
@@ -193,6 +194,11 @@ class MessagingSocketService {
       this.emit('conversation:pins:updated', data);
     });
 
+    // Message edit events
+    this.socket.on('conversation:message:edited', (data: { message: ConversationMessage }) => {
+      this.emit('conversation:message:edited', data);
+    });
+
     // Notification events
     this.socket.on('notification:new', (notification: Notification) => {
       this.emit('notification:new', notification);
@@ -301,6 +307,20 @@ class MessagingSocketService {
   ): void {
     if (!this.socket?.connected) return;
     this.socket.emit('conversation:unpin', { messageId }, callback);
+  }
+
+  // ========================================
+  // MESSAGE EDITING
+  // ========================================
+
+  editMessage(
+    conversationId: string,
+    messageId: string,
+    content: string,
+    callback?: (response: { ok: boolean; message?: ConversationMessage; error?: string }) => void
+  ): void {
+    if (!this.socket?.connected) return;
+    this.socket.emit('conversation:message:edit', { conversationId, messageId, content }, callback);
   }
 
   // ========================================


### PR DESCRIPTION
- Add editMessage adapter method with ownership verification
- Add PATCH /api/messages/:messageId REST endpoint
- Add WebSocket event handlers for message editing
- Add editMessage to messagingSocketService and useConversationRealtime hook
- Wire inline editing UI in MessageBubble with textarea, keyboard shortcuts
- Show "edited" label next to message timestamp for edited messages
- Add Edit option to MessageActionsMenu for own messages