### PR TITLE
feat(messaging): Add message search with scoped and global options

### DIFF
--- a/database/migrations/041_message_search_indexes.sql
+++ b/database/migrations/041_message_search_indexes.sql
@@ -1,0 +1,20 @@
+-- Migration 041: Add indexes to support message search
+-- Date: 2025-12-13
+-- Description:
+--   Adds indexes to speed up ILIKE text searches and
+--   conversation-scoped message retrieval.
+
+-- ===========================================
+-- Messages: lowercase index for ILIKE searches
+-- ===========================================
+-- Using a functional index on lower(text) to speed up case-insensitive searches
+CREATE INDEX IF NOT EXISTS idx_messages_text_lower
+  ON messages (LOWER(text));
+
+-- ===========================================
+-- Messages: composite index for conversation-scoped queries
+-- ===========================================
+-- Helps when searching within a specific conversation sorted by time
+CREATE INDEX IF NOT EXISTS idx_messages_conversation_created
+  ON messages (conversation_id, created_at DESC);
+

--- a/server-unified.js
+++ b/server-unified.js
@@ -3899,6 +3899,45 @@ app.patch('/api/messages/:messageId', authenticateToken, async (req, res) => {
   }
 });
 
+// ----- Message Search -----
+
+// 10i. GET /api/messages/search - Search messages across conversations
+app.get('/api/messages/search', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const searchQuery = req.query.q;
+    const conversationId = req.query.conversationId || null;
+    const limit = Math.min(parseInt(req.query.limit, 10) || 50, 100);
+    const offset = parseInt(req.query.offset, 10) || 0;
+
+    if (!searchQuery || searchQuery.trim().length < 2) {
+      return res.status(400).json({
+        success: false,
+        error: 'Search query must be at least 2 characters'
+      });
+    }
+
+    const results = await messagingConversationsAdapter.searchMessages({
+      userId,
+      query: searchQuery,
+      conversationId,
+      limit,
+      offset
+    });
+
+    return res.json({
+      success: true,
+      results,
+      query: searchQuery.trim(),
+      conversationId,
+      pagination: { limit, offset }
+    });
+  } catch (error) {
+    console.error('Error searching messages:', error);
+    return res.status(500).json({ success: false, error: 'Failed to search messages' });
+  }
+});
+
 // ----- Notifications -----
 
 // 11. GET /api/notifications - List notifications for current user

--- a/src/components/messaging/MessageSearchPanel.tsx
+++ b/src/components/messaging/MessageSearchPanel.tsx
@@ -1,0 +1,271 @@
+/**
+ * Message Search Panel Component
+ * Provides UI for searching messages within a conversation or globally
+ */
+
+import React, { useRef, useEffect } from 'react';
+import { Search, X, Loader2, Globe, MessageCircle, ChevronRight, Hash } from 'lucide-react';
+import { useMessageSearch, MessageSearchResult } from '../../hooks/useMessageSearch';
+import { cn } from '../../lib/utils';
+
+interface MessageSearchPanelProps {
+  /** Current conversation ID for scoped search (null for global) */
+  conversationId?: string | null;
+  /** Whether to start with global search enabled */
+  defaultGlobal?: boolean;
+  /** Callback when a search result is clicked */
+  onResultClick: (result: MessageSearchResult) => void;
+  /** Callback to close the panel */
+  onClose: () => void;
+  /** Additional class names */
+  className?: string;
+}
+
+const formatTime = (dateString: string) => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 1) return 'now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+};
+
+function highlightMatch(text: string, query: string): React.ReactNode {
+  if (!query.trim()) return text;
+
+  const parts = text.split(new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi'));
+
+  return (
+    <>
+      {parts.map((part, i) =>
+        part.toLowerCase() === query.toLowerCase() ? (
+          <mark key={i} className="bg-yellow-200 dark:bg-yellow-700 text-inherit rounded px-0.5">
+            {part}
+          </mark>
+        ) : (
+          part
+        )
+      )}
+    </>
+  );
+}
+
+export function MessageSearchPanel({
+  conversationId,
+  defaultGlobal = false,
+  onResultClick,
+  onClose,
+  className,
+}: MessageSearchPanelProps) {
+  const [isGlobalSearch, setIsGlobalSearch] = React.useState(defaultGlobal || !conversationId);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const {
+    query,
+    setQuery,
+    debouncedQuery,
+    results,
+    isLoading,
+    error,
+    clearSearch,
+    resultCount,
+    isSearchActive,
+    loadMore,
+    hasMore,
+  } = useMessageSearch({
+    conversationId: isGlobalSearch ? null : conversationId,
+    debounceDelay: 300,
+    limit: 30,
+  });
+
+  // Focus input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Handle keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const handleResultClick = (result: MessageSearchResult) => {
+    onResultClick(result);
+  };
+
+  return (
+    <div className={cn(
+      'flex flex-col bg-white dark:bg-neutral-900 border-b border-neutral-200 dark:border-neutral-700',
+      className
+    )}>
+      {/* Search Header */}
+      <div className="p-3 border-b border-neutral-100 dark:border-neutral-800">
+        <div className="flex items-center gap-2">
+          <div className="flex-1 relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400" />
+            <input
+              ref={inputRef}
+              type="text"
+              placeholder={isGlobalSearch ? 'Search all messages...' : 'Search in this conversation...'}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="w-full pl-10 pr-10 py-2 text-sm border border-neutral-200 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+            {query && (
+              <button
+                onClick={clearSearch}
+                className="absolute right-3 top-1/2 -translate-y-1/2 p-1 hover:bg-neutral-100 dark:hover:bg-neutral-700 rounded"
+              >
+                <X className="w-4 h-4 text-neutral-400" />
+              </button>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-lg"
+            title="Close search"
+          >
+            <X className="w-5 h-5 text-neutral-600 dark:text-neutral-400" />
+          </button>
+        </div>
+
+        {/* Search scope toggle */}
+        {conversationId && (
+          <div className="flex items-center gap-2 mt-2">
+            <button
+              onClick={() => setIsGlobalSearch(false)}
+              className={cn(
+                'flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-full transition-colors',
+                !isGlobalSearch
+                  ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300'
+                  : 'bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700'
+              )}
+            >
+              <MessageCircle className="w-3.5 h-3.5" />
+              This conversation
+            </button>
+            <button
+              onClick={() => setIsGlobalSearch(true)}
+              className={cn(
+                'flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-full transition-colors',
+                isGlobalSearch
+                  ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300'
+                  : 'bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700'
+              )}
+            >
+              <Globe className="w-3.5 h-3.5" />
+              All conversations
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Search Results */}
+      <div className="flex-1 overflow-y-auto max-h-80">
+        {isLoading && results.length === 0 ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="w-5 h-5 text-primary-600 animate-spin" />
+            <span className="ml-2 text-sm text-neutral-500">Searching...</span>
+          </div>
+        ) : error ? (
+          <div className="p-4 text-center">
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          </div>
+        ) : !isSearchActive ? (
+          <div className="p-6 text-center">
+            <Search className="w-10 h-10 text-neutral-300 dark:text-neutral-600 mx-auto mb-3" />
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              Type to search messages
+            </p>
+            <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1">
+              Minimum 2 characters required
+            </p>
+          </div>
+        ) : results.length === 0 ? (
+          <div className="p-6 text-center">
+            <MessageCircle className="w-10 h-10 text-neutral-300 dark:text-neutral-600 mx-auto mb-3" />
+            <p className="text-sm text-neutral-600 dark:text-neutral-400">
+              No messages found for "{debouncedQuery}"
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Results count */}
+            <div className="px-3 py-2 bg-neutral-50 dark:bg-neutral-800/50 border-b border-neutral-100 dark:border-neutral-800">
+              <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                {resultCount} result{resultCount !== 1 ? 's' : ''} found
+              </p>
+            </div>
+
+            {/* Results list */}
+            {results.map((result) => (
+              <button
+                key={result.id}
+                onClick={() => handleResultClick(result)}
+                className="w-full p-3 flex items-start gap-3 hover:bg-neutral-50 dark:hover:bg-neutral-800/50 transition-colors text-left border-b border-neutral-100 dark:border-neutral-800 last:border-b-0"
+              >
+                <div className="w-8 h-8 rounded-full bg-gradient-to-br from-primary-500 to-indigo-600 flex items-center justify-center text-white text-xs font-medium flex-shrink-0">
+                  {result.userName?.[0]?.toUpperCase() || 'U'}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between gap-2 mb-0.5">
+                    <span className="text-sm font-medium text-neutral-900 dark:text-neutral-100 truncate">
+                      {result.userName || 'Unknown User'}
+                    </span>
+                    <span className="text-xs text-neutral-400 flex-shrink-0">
+                      {formatTime(result.createdAt)}
+                    </span>
+                  </div>
+                  {isGlobalSearch && result.conversationName && (
+                    <div className="flex items-center gap-1 mb-1">
+                      <Hash className="w-3 h-3 text-neutral-400" />
+                      <span className="text-xs text-neutral-500 dark:text-neutral-400 truncate">
+                        {result.conversationName}
+                      </span>
+                    </div>
+                  )}
+                  <p className="text-sm text-neutral-600 dark:text-neutral-400 line-clamp-2">
+                    {highlightMatch(result.text, debouncedQuery)}
+                  </p>
+                </div>
+                <ChevronRight className="w-4 h-4 text-neutral-400 flex-shrink-0 mt-2" />
+              </button>
+            ))}
+
+            {/* Load more button */}
+            {hasMore && (
+              <button
+                onClick={loadMore}
+                disabled={isLoading}
+                className="w-full py-3 text-sm text-primary-600 dark:text-primary-400 hover:bg-neutral-50 dark:hover:bg-neutral-800/50 disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                {isLoading ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Loading...
+                  </>
+                ) : (
+                  'Load more results'
+                )}
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MessageSearchPanel;

--- a/src/hooks/useMessageSearch.ts
+++ b/src/hooks/useMessageSearch.ts
@@ -1,0 +1,263 @@
+/**
+ * useMessageSearch Hook - Flux Studio
+ *
+ * Custom hook for searching messages with debounced API calls.
+ * Supports both scoped (single conversation) and global (all conversations) search.
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+
+// ============================================================================
+// TYPE DEFINITIONS
+// ============================================================================
+
+export interface MessageSearchResult {
+  id: string;
+  userId: string;
+  conversationId: string;
+  text: string;
+  assetId?: string;
+  replyToMessageId?: string;
+  projectId?: string;
+  isSystemMessage: boolean;
+  createdAt: string;
+  editedAt?: string;
+  originalMessageId?: string;
+  userName?: string;
+  userAvatar?: string;
+  conversationName?: string;
+  conversationIsGroup?: boolean;
+}
+
+export interface UseMessageSearchOptions {
+  /** Optional conversation ID to scope search */
+  conversationId?: string | null;
+  /** Debounce delay in ms (default: 300) */
+  debounceDelay?: number;
+  /** Maximum results to fetch (default: 50) */
+  limit?: number;
+  /** Minimum query length to trigger search (default: 2) */
+  minQueryLength?: number;
+}
+
+export interface UseMessageSearchReturn {
+  /** Current search query */
+  query: string;
+  /** Set the search query */
+  setQuery: (query: string) => void;
+  /** Debounced query that triggers API calls */
+  debouncedQuery: string;
+  /** Search results */
+  results: MessageSearchResult[];
+  /** Loading state */
+  isLoading: boolean;
+  /** Error message if search failed */
+  error: string | null;
+  /** Clear search query and results */
+  clearSearch: () => void;
+  /** Number of results */
+  resultCount: number;
+  /** Whether search is active (has query) */
+  isSearchActive: boolean;
+  /** Load more results (pagination) */
+  loadMore: () => Promise<void>;
+  /** Whether there are more results to load */
+  hasMore: boolean;
+}
+
+// ============================================================================
+// DEBOUNCE HOOK
+// ============================================================================
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+// ============================================================================
+// MAIN HOOK
+// ============================================================================
+
+export function useMessageSearch(options: UseMessageSearchOptions = {}): UseMessageSearchReturn {
+  const {
+    conversationId = null,
+    debounceDelay = 300,
+    limit = 50,
+    minQueryLength = 2,
+  } = options;
+
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<MessageSearchResult[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+
+  // Debounce the query
+  const debouncedQuery = useDebounce(query, debounceDelay);
+
+  // Reset offset when query or conversationId changes
+  useEffect(() => {
+    setOffset(0);
+    setResults([]);
+    setHasMore(false);
+  }, [debouncedQuery, conversationId]);
+
+  // Perform search when debounced query changes
+  useEffect(() => {
+    const performSearch = async () => {
+      // Don't search if query is too short
+      if (!debouncedQuery || debouncedQuery.trim().length < minQueryLength) {
+        setResults([]);
+        setError(null);
+        setHasMore(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const token = localStorage.getItem('auth_token');
+        if (!token) {
+          throw new Error('Not authenticated');
+        }
+
+        // Build query params
+        const params = new URLSearchParams({
+          q: debouncedQuery.trim(),
+          limit: String(limit),
+          offset: '0',
+        });
+
+        if (conversationId) {
+          params.set('conversationId', conversationId);
+        }
+
+        const response = await fetch(`/api/messages/search?${params.toString()}`, {
+          method: 'GET',
+          headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (!response.ok) {
+          const data = await response.json();
+          throw new Error(data.error || 'Search failed');
+        }
+
+        const data = await response.json();
+
+        if (data.success) {
+          setResults(data.results || []);
+          setHasMore((data.results || []).length >= limit);
+        } else {
+          throw new Error(data.error || 'Search failed');
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Search failed';
+        setError(message);
+        setResults([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    performSearch();
+  }, [debouncedQuery, conversationId, limit, minQueryLength]);
+
+  // Load more results
+  const loadMore = useCallback(async () => {
+    if (!debouncedQuery || debouncedQuery.trim().length < minQueryLength || isLoading || !hasMore) {
+      return;
+    }
+
+    const newOffset = offset + limit;
+    setIsLoading(true);
+
+    try {
+      const token = localStorage.getItem('auth_token');
+      if (!token) {
+        throw new Error('Not authenticated');
+      }
+
+      const params = new URLSearchParams({
+        q: debouncedQuery.trim(),
+        limit: String(limit),
+        offset: String(newOffset),
+      });
+
+      if (conversationId) {
+        params.set('conversationId', conversationId);
+      }
+
+      const response = await fetch(`/api/messages/search?${params.toString()}`, {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || 'Load more failed');
+      }
+
+      const data = await response.json();
+
+      if (data.success) {
+        const newResults = data.results || [];
+        setResults(prev => [...prev, ...newResults]);
+        setOffset(newOffset);
+        setHasMore(newResults.length >= limit);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Load more failed';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [debouncedQuery, conversationId, limit, minQueryLength, offset, isLoading, hasMore]);
+
+  // Clear search
+  const clearSearch = useCallback(() => {
+    setQuery('');
+    setResults([]);
+    setError(null);
+    setOffset(0);
+    setHasMore(false);
+  }, []);
+
+  // Computed values
+  const isSearchActive = useMemo(() => query.trim().length >= minQueryLength, [query, minQueryLength]);
+  const resultCount = results.length;
+
+  return {
+    query,
+    setQuery,
+    debouncedQuery,
+    results,
+    isLoading,
+    error,
+    clearSearch,
+    resultCount,
+    isSearchActive,
+    loadMore,
+    hasMore,
+  };
+}
+
+export default useMessageSearch;


### PR DESCRIPTION
- Add DB migration with indexes for text search (LOWER(text) and conversation_id, created_at)
- Add searchMessages adapter method with ILIKE pattern matching
- Add REST endpoint GET /api/messages/search with pagination
- Create useMessageSearch hook with debounced API calls
- Create MessageSearchPanel component with scoped/global toggle
- Integrate search UI into MessagesNew with Ctrl+F shortcut
- Wire search results to jump-to-message with conversation switching