### PR TITLE
feat: implement Project Context Everywhere

### DIFF
--- a/database/messaging-conversations-adapter.js
+++ b/database/messaging-conversations-adapter.js
@@ -25,6 +25,7 @@ class MessagingConversationsAdapter {
    *
    * @param {Object} params
    * @param {string} [params.organizationId] - Organization scope
+   * @param {string} [params.projectId] - Optional project scope for project-linked conversations
    * @param {string} [params.name] - Conversation name (for groups)
    * @param {boolean} [params.isGroup=false] - Group vs DM
    * @param {string} params.creatorUserId - User creating the conversation
@@ -33,6 +34,7 @@ class MessagingConversationsAdapter {
    */
   async createConversation({
     organizationId = null,
+    projectId = null,
     name = null,
     isGroup = false,
     creatorUserId,
@@ -43,10 +45,10 @@ class MessagingConversationsAdapter {
     return await transaction(async (client) => {
       // Insert conversation
       const convResult = await client.query(`
-        INSERT INTO conversations (id, organization_id, name, is_group, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, NOW(), NOW())
+        INSERT INTO conversations (id, organization_id, project_id, name, is_group, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
         RETURNING *
-      `, [conversationId, organizationId, name, isGroup]);
+      `, [conversationId, organizationId, projectId, name, isGroup]);
 
       const conversation = this._transformConversation(convResult.rows[0]);
 
@@ -110,10 +112,12 @@ class MessagingConversationsAdapter {
         SELECT
           c.id,
           c.organization_id,
+          c.project_id,
           c.name,
           c.is_group,
           c.created_at,
           c.updated_at,
+          p.name as project_name,
           uc.last_read_message_id,
           uc.member_since,
           MAX(m.created_at) as last_message_at,
@@ -137,8 +141,9 @@ class MessagingConversationsAdapter {
         FROM conversations c
         INNER JOIN user_convs uc ON c.id = uc.conversation_id
         LEFT JOIN messages m ON m.conversation_id = c.id
-        GROUP BY c.id, c.organization_id, c.name, c.is_group, c.created_at, c.updated_at,
-                 uc.last_read_message_id, uc.member_since
+        LEFT JOIN projects p ON c.project_id = p.id
+        GROUP BY c.id, c.organization_id, c.project_id, c.name, c.is_group, c.created_at, c.updated_at,
+                 p.name, uc.last_read_message_id, uc.member_since
       )
       SELECT *
       FROM conv_stats
@@ -149,6 +154,8 @@ class MessagingConversationsAdapter {
     return result.rows.map(row => ({
       id: row.id,
       organizationId: row.organization_id,
+      projectId: row.project_id || null,
+      projectName: row.project_name || null,
       name: row.name,
       isGroup: row.is_group,
       createdAt: row.created_at,
@@ -179,9 +186,12 @@ class MessagingConversationsAdapter {
       return null; // User is not a member
     }
 
-    // Get conversation
+    // Get conversation with project name
     const convResult = await query(`
-      SELECT * FROM conversations WHERE id = $1
+      SELECT c.*, p.name as project_name
+      FROM conversations c
+      LEFT JOIN projects p ON c.project_id = p.id
+      WHERE c.id = $1
     `, [conversationId]);
 
     if (convResult.rows.length === 0) {
@@ -960,6 +970,8 @@ class MessagingConversationsAdapter {
    * @param {string} [params.messageId] - For deep linking to message
    * @param {string} [params.threadRootMessageId] - For opening thread panel
    * @param {string} [params.assetId] - For file_shared notifications
+   * @param {string} [params.projectId] - For project-scoped notifications
+   * @param {string} [params.projectName] - Denormalized project name for display
    * @param {Object} [params.metadata] - Additional metadata
    * @param {string} [params.entityId] - Legacy: related entity ID
    * @returns {Object} Created notification
@@ -974,6 +986,8 @@ class MessagingConversationsAdapter {
     messageId = null,
     threadRootMessageId = null,
     assetId = null,
+    projectId = null,
+    projectName = null,
     metadata = {},
     entityId = null
   }) {
@@ -982,14 +996,15 @@ class MessagingConversationsAdapter {
     const result = await query(`
       INSERT INTO notifications (
         id, user_id, type, entity_id, title, body, is_read, created_at,
-        actor_user_id, conversation_id, message_id, thread_root_message_id, asset_id, metadata_json
+        actor_user_id, conversation_id, message_id, thread_root_message_id, asset_id,
+        project_id, project_name, metadata_json
       )
-      VALUES ($1, $2, $3, $4, $5, $6, FALSE, NOW(), $7, $8, $9, $10, $11, $12)
+      VALUES ($1, $2, $3, $4, $5, $6, FALSE, NOW(), $7, $8, $9, $10, $11, $12, $13, $14)
       RETURNING *
     `, [
       id, userId, type, entityId, title, body,
       actorUserId, conversationId, messageId, threadRootMessageId, assetId,
-      JSON.stringify(metadata)
+      projectId, projectName, JSON.stringify(metadata)
     ]);
 
     return this._transformNotification(result.rows[0]);
@@ -1276,6 +1291,8 @@ class MessagingConversationsAdapter {
     return {
       id: row.id,
       organizationId: row.organization_id,
+      projectId: row.project_id || null,
+      projectName: row.project_name || null,
       name: row.name,
       isGroup: row.is_group,
       createdAt: row.created_at,
@@ -1464,6 +1481,9 @@ class MessagingConversationsAdapter {
       messageId: row.message_id,
       threadRootMessageId: row.thread_root_message_id,
       assetId: row.asset_id,
+      // Project context for project-scoped notifications
+      projectId: row.project_id || null,
+      projectName: row.project_name || null,
       metadata: row.metadata_json || {}
     };
 

--- a/database/migrations/045_project_context_everywhere.sql
+++ b/database/migrations/045_project_context_everywhere.sql
@@ -1,0 +1,47 @@
+-- Migration 045: Project Context Everywhere
+-- Date: 2025-12-14
+-- Description:
+--   Adds project context to conversations and notifications tables
+--   to support "Projects are the home for everything" UX principle.
+--
+-- This migration adds:
+-- 1. project_id FK on conversations table
+-- 2. project_id and project_name on notifications table
+--
+-- All columns are nullable to maintain backwards compatibility.
+-- Existing rows will have NULL values (no project context).
+
+-- ===========================================
+-- 1. Conversations: Add project context
+-- ===========================================
+
+-- Add project_id to conversations (nullable FK)
+ALTER TABLE conversations
+  ADD COLUMN IF NOT EXISTS project_id TEXT REFERENCES projects(id) ON DELETE SET NULL;
+
+-- Create index for project-scoped conversation lookups
+CREATE INDEX IF NOT EXISTS idx_conversations_project
+  ON conversations(project_id) WHERE project_id IS NOT NULL;
+
+-- Comment for documentation
+COMMENT ON COLUMN conversations.project_id IS 'Optional project scope for project-scoped conversations';
+
+-- ===========================================
+-- 2. Notifications: Add project context
+-- ===========================================
+
+-- Add project_id to notifications (nullable, no FK to allow denormalization)
+ALTER TABLE notifications
+  ADD COLUMN IF NOT EXISTS project_id TEXT;
+
+-- Add project_name denormalized for display (avoids join on read)
+ALTER TABLE notifications
+  ADD COLUMN IF NOT EXISTS project_name TEXT;
+
+-- Create index for project-scoped notification lookups
+CREATE INDEX IF NOT EXISTS idx_notifications_project
+  ON notifications(project_id) WHERE project_id IS NOT NULL;
+
+-- Comments for documentation
+COMMENT ON COLUMN notifications.project_id IS 'Project ID for project-scoped notifications';
+COMMENT ON COLUMN notifications.project_name IS 'Denormalized project name at notification creation time';

--- a/services/notification-service.js
+++ b/services/notification-service.js
@@ -24,6 +24,8 @@ class NotificationService {
    * @param {Object} [params.replyToMessage] - The message being replied to (if any)
    * @param {Object} [params.threadRootMessage] - The thread root message (if any)
    * @param {Array} [params.conversationMembers] - Array of { userId } for all members
+   * @param {string} [params.projectId] - Project ID for project-scoped conversations
+   * @param {string} [params.projectName] - Project name for display
    * @returns {Array} Array of created notifications
    */
   async processMessageNotifications({
@@ -33,7 +35,9 @@ class NotificationService {
     senderName,
     replyToMessage = null,
     threadRootMessage = null,
-    conversationMembers = []
+    conversationMembers = [],
+    projectId = null,
+    projectName = null
   }) {
     const notifications = [];
     const notifiedUserIds = new Set(); // Track to avoid duplicates
@@ -49,7 +53,9 @@ class NotificationService {
         senderId,
         senderName,
         notifiedUserIds,
-        conversationMembers
+        conversationMembers,
+        projectId,
+        projectName
       });
       notifications.push(...mentionedNotifications);
     }
@@ -61,7 +67,9 @@ class NotificationService {
         conversationId,
         senderId,
         senderName,
-        replyToMessage
+        replyToMessage,
+        projectId,
+        projectName
       });
       if (replyNotification) {
         notifications.push(replyNotification);
@@ -76,7 +84,9 @@ class NotificationService {
         conversationId,
         senderId,
         senderName,
-        threadRootMessage
+        threadRootMessage,
+        projectId,
+        projectName
       });
       if (threadNotification) {
         notifications.push(threadNotification);
@@ -92,7 +102,9 @@ class NotificationService {
         senderId,
         senderName,
         notifiedUserIds,
-        conversationMembers
+        conversationMembers,
+        projectId,
+        projectName
       });
       notifications.push(...fileNotifications);
     }
@@ -112,7 +124,9 @@ class NotificationService {
     senderId,
     senderName,
     notifiedUserIds,
-    conversationMembers
+    conversationMembers,
+    projectId = null,
+    projectName = null
   }) {
     const notifications = [];
 
@@ -149,7 +163,9 @@ class NotificationService {
             conversationId,
             messageId: message.id,
             threadRootMessageId: message.threadRootMessageId || null,
-            assetId: message.assetId || null
+            assetId: message.assetId || null,
+            projectId,
+            projectName
           });
 
           notifications.push(notification);
@@ -170,7 +186,9 @@ class NotificationService {
     conversationId,
     senderId,
     senderName,
-    replyToMessage
+    replyToMessage,
+    projectId = null,
+    projectName = null
   }) {
     if (!replyToMessage.authorId || replyToMessage.authorId === senderId) {
       return null;
@@ -185,7 +203,9 @@ class NotificationService {
       conversationId,
       messageId: message.id,
       threadRootMessageId: null, // Direct reply, not thread
-      assetId: message.assetId || null
+      assetId: message.assetId || null,
+      projectId,
+      projectName
     });
   }
 
@@ -197,7 +217,9 @@ class NotificationService {
     conversationId,
     senderId,
     senderName,
-    threadRootMessage
+    threadRootMessage,
+    projectId = null,
+    projectName = null
   }) {
     if (!threadRootMessage.authorId || threadRootMessage.authorId === senderId) {
       return null;
@@ -212,7 +234,9 @@ class NotificationService {
       conversationId,
       messageId: message.id,
       threadRootMessageId: threadRootMessage.id,
-      assetId: message.assetId || null
+      assetId: message.assetId || null,
+      projectId,
+      projectName
     });
   }
 
@@ -227,7 +251,9 @@ class NotificationService {
     senderId,
     senderName,
     notifiedUserIds,
-    conversationMembers
+    conversationMembers,
+    projectId = null,
+    projectName = null
   }) {
     const notifications = [];
 
@@ -258,7 +284,9 @@ class NotificationService {
         conversationId,
         messageId: message.id,
         threadRootMessageId: message.threadRootMessageId || null,
-        assetId: message.assetId
+        assetId: message.assetId,
+        projectId,
+        projectName
       });
 
       notifications.push(notification);

--- a/src/hooks/useProjectCounts.ts
+++ b/src/hooks/useProjectCounts.ts
@@ -1,0 +1,86 @@
+/**
+ * useProjectCounts - Hook for fetching project content counts
+ *
+ * Fetches counts from GET /api/projects/:projectId/counts for tab badges.
+ * Returns: { messages, files, assets, boards }
+ *
+ * Usage:
+ * const { counts, loading, error, refetch } = useProjectCounts(projectId);
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { getApiUrl } from '@/utils/apiHelpers';
+
+export interface ProjectCounts {
+  messages: number;
+  files: number;
+  assets: number;
+  boards: number;
+}
+
+interface UseProjectCountsResult {
+  counts: ProjectCounts | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+export function useProjectCounts(projectId: string | undefined): UseProjectCountsResult {
+  const [counts, setCounts] = useState<ProjectCounts | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCounts = useCallback(async () => {
+    if (!projectId) {
+      setCounts(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const token = localStorage.getItem('auth_token');
+      const response = await fetch(getApiUrl(`/projects/${projectId}/counts`), {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch counts: ${response.status}`);
+      }
+
+      const data = await response.json();
+      if (data.success && data.counts) {
+        setCounts(data.counts);
+      } else {
+        throw new Error(data.error || 'Invalid response');
+      }
+    } catch (err) {
+      console.error('Error fetching project counts:', err);
+      setError(err instanceof Error ? err.message : 'Unknown error');
+      // Set default counts on error to avoid breaking the UI
+      setCounts({
+        messages: 0,
+        files: 0,
+        assets: 0,
+        boards: 0,
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    fetchCounts();
+  }, [fetchCounts]);
+
+  return {
+    counts,
+    loading,
+    error,
+    refetch: fetchCounts,
+  };
+}

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -67,6 +67,7 @@ import {
 import { useTaskRealtime } from '@/hooks/useTaskRealtime';
 import { useAssets, AssetRecord } from '@/contexts/AssetsContext';
 import { AssetDetailDrawer } from '@/components/assets/AssetDetailDrawer';
+import { useProjectCounts } from '@/hooks/useProjectCounts';
 import { cn } from '@/lib/utils';
 
 // ============================================================================
@@ -198,7 +199,9 @@ export const ProjectDetail = () => {
   // ============================================================================
 
   const [activeTab, setActiveTab] = React.useState('overview');
-  const [unreadCount] = React.useState(0); // TODO: Wire up to messaging context
+  // Fetch project counts from API for tab badges
+  const { counts: projectCounts } = useProjectCounts(id);
+  const messagesCount = projectCounts?.messages ?? 0;
 
   // Task view state
   const [viewMode, setViewMode] = React.useState<ViewMode>(() => {
@@ -672,16 +675,13 @@ export const ProjectDetail = () => {
                 aria-selected={activeTab === 'messages'}
                 aria-controls="messages-panel"
                 id="messages-tab"
-                aria-label={unreadCount > 0 ? `Messages, ${unreadCount} unread` : 'Messages'}
+                aria-label={`Messages, ${messagesCount} conversations`}
               >
                 <MessageSquare className="h-4 w-4 mr-2" aria-hidden="true" />
                 Messages
-                {unreadCount > 0 && (
-                  <Badge variant="solidError" size="sm" className="ml-2">
-                    <span className="sr-only">{unreadCount} unread</span>
-                    <span aria-hidden="true">{unreadCount}</span>
-                  </Badge>
-                )}
+                <Badge variant="outline" size="sm" className="ml-2" aria-hidden="true">
+                  {messagesCount}
+                </Badge>
               </TabsTrigger>
             </TabsList>
           </Tabs>


### PR DESCRIPTION
This commit adds project context to conversations, notifications, and project detail tabs, supporting the "Projects are home" UX principle.

Backend Changes:
- Migration 045: Add project_id to conversations and notifications tables
- Conversations: Support project-linked conversations with projectId/projectName
- Notifications: Store project context for project-scoped notifications
- New endpoint: GET /api/projects/:projectId/counts for tab badges

Frontend Changes:
- Messages: Project badge on conversation rows (clickable)
- Notifications: Project badge + "Project Only" filter
- ProjectDetail: Messages tab count from API via useProjectCounts hook

Files Modified:
- database/migrations/045_project_context_everywhere.sql (NEW)
- database/messaging-conversations-adapter.js
- services/notification-service.js
- server-unified.js
- src/pages/MessagesNew.tsx
- src/pages/Notifications.tsx
- src/pages/ProjectDetail.tsx
- src/hooks/useProjectCounts.ts (NEW)
- docs/project-context-followups.md (updated)