### PR TITLE
fix(context): remove hydration gate from ActiveProjectProvider

### DIFF
--- a/src/contexts/ActiveProjectContext.tsx
+++ b/src/contexts/ActiveProjectContext.tsx
@@ -114,11 +114,8 @@ export function ActiveProjectProvider({ children }: { children: React.ReactNode 
     [activeProject, setActiveProject, clearActiveProject, isProjectFocused, hasFocus]
   );
 
-  // Avoid flash of wrong state during hydration
-  if (!isHydrated) {
-    return null;
-  }
-
+  // Always render provider with current value - hydration happens in background
+  // This prevents "must be used within provider" errors during initial render
   return (
     <ActiveProjectContext.Provider value={value}>
       {children}


### PR DESCRIPTION
The previous implementation returned null during localStorage hydration, which could cause "useActiveProject must be used within provider" errors during initial render. Now always renders the provider with current value, letting hydration happen in the background.