### PR TITLE
fix(auth): Handle 401 race condition in React rendering

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -45,6 +45,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     // Check for existing session
     checkAuth();
+
+    // Listen for 401 unauthorized events from API service
+    const handleUnauthorized = () => {
+      // Immediately clear user state to trigger redirect via ProtectedRoute
+      setUser(null);
+      setIsLoading(false);
+    };
+
+    window.addEventListener('auth:unauthorized', handleUnauthorized);
+    return () => {
+      window.removeEventListener('auth:unauthorized', handleUnauthorized);
+    };
   }, []);
 
   const checkAuth = async () => {

--- a/src/pages/MessagesNew.tsx
+++ b/src/pages/MessagesNew.tsx
@@ -26,7 +26,7 @@ import { DashboardLayout } from '@/components/templates';
 import { ChatMessage, UserCard } from '@/components/molecules';
 import { Button, Card, Badge, Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui';
 import { useAuth } from '../contexts/AuthContext';
-import { useActiveProject } from '../contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '../contexts/ActiveProjectContext';
 import { useConversationRealtime } from '../hooks/useConversationRealtime';
 import { messagingSocketService, ConversationMessage } from '../services/messagingSocketService';
 import {
@@ -1610,8 +1610,17 @@ function PinnedMessagesPanel({
 // Main Messages Component
 function MessagesNew() {
   const { user, logout } = useAuth();
-  const { activeProject, hasFocus } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
   const navigate = useNavigate();
+
+  // Guard: If auth context indicates no user, return null and let ProtectedRoute redirect
+  if (!user) {
+    return null;
+  }
+
+  // Safe destructure with fallback values (handles hydration and 401 race conditions)
+  const activeProject = activeProjectContext?.activeProject ?? null;
+  const hasFocus = activeProjectContext?.hasFocus ?? false;
   const [searchParams, setSearchParams] = useSearchParams();
   const { reportConversation } = useReportEntityFocus();
 


### PR DESCRIPTION
- Add auth:unauthorized event listener in AuthContext to immediately clear user state when 401 occurs, triggering ProtectedRoute redirect
- Update MessagesNew to use useActiveProjectOptional hook instead of throwing variant, preventing context errors during auth transitions
- Add user guard in MessagesNew to return null if user is null, allowing ProtectedRoute to handle the redirect gracefully

This prevents the white screen crash when API returns 401 by ensuring React state updates before components try to render with stale context.