### PR TITLE
fix(context): Use optional hook for all ActiveProject consumers

### DIFF
--- a/src/components/projects/ProjectContextBar.tsx
+++ b/src/components/projects/ProjectContextBar.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Target, ExternalLink, X } from 'lucide-react';
 import { Button } from '@/components/ui';
-import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '@/contexts/ActiveProjectContext';
 import { PulseIndicator } from '@/components/pulse/PulseIndicator';
 import { PulsePanel } from '@/components/pulse/PulsePanel';
 import { cn } from '@/lib/utils';
@@ -28,10 +28,15 @@ export interface ProjectContextBarProps {
 }
 
 export function ProjectContextBar({ className }: ProjectContextBarProps) {
-  const { activeProject, clearActiveProject, hasFocus } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
   const [isPulseOpen, setIsPulseOpen] = React.useState(false);
 
-  // Don't render if no project is focused
+  // Safe access with fallbacks - handles 401 race conditions
+  const activeProject = activeProjectContext?.activeProject ?? null;
+  const hasFocus = activeProjectContext?.hasFocus ?? false;
+  const clearActiveProject = activeProjectContext?.clearActiveProject ?? (() => {});
+
+  // Don't render if no project is focused or context unavailable
   if (!hasFocus || !activeProject) {
     return null;
   }

--- a/src/components/pulse/PulsePanel.tsx
+++ b/src/components/pulse/PulsePanel.tsx
@@ -23,7 +23,7 @@ import {
 import { Button, Badge } from '@/components/ui';
 import { cn } from '@/lib/utils';
 import { useProjectPulse } from '@/hooks/useProjectPulse';
-import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '@/contexts/ActiveProjectContext';
 import { ActivityStream } from './ActivityStream';
 import { AttentionInbox } from './AttentionInbox';
 import { TeamHeartbeat } from './TeamHeartbeat';
@@ -55,7 +55,8 @@ export function PulsePanel({
   position = 'right',
 }: PulsePanelProps) {
   const navigate = useNavigate();
-  const { activeProject } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const activeProject = activeProjectContext?.activeProject ?? null;
   const {
     activityStream,
     attentionItems,

--- a/src/components/pulse/QuickActions.tsx
+++ b/src/components/pulse/QuickActions.tsx
@@ -31,7 +31,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui';
 import { cn } from '@/lib/utils';
-import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '@/contexts/ActiveProjectContext';
 
 export interface QuickActionsProps {
   /** Whether the palette is open */
@@ -54,7 +54,9 @@ export interface QuickAction {
 
 export function QuickActions({ isOpen, onClose, onAction }: QuickActionsProps) {
   const navigate = useNavigate();
-  const { activeProject, hasFocus } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const activeProject = activeProjectContext?.activeProject ?? null;
+  const hasFocus = activeProjectContext?.hasFocus ?? false;
   const [search, setSearch] = React.useState('');
   const [selectedIndex, setSelectedIndex] = React.useState(0);
   const inputRef = React.useRef<HTMLInputElement>(null);

--- a/src/contexts/WorkingContext.tsx
+++ b/src/contexts/WorkingContext.tsx
@@ -12,7 +12,7 @@
  */
 
 import * as React from 'react';
-import { useActiveProject } from './ActiveProjectContext';
+import { useActiveProjectOptional } from './ActiveProjectContext';
 
 // Current schema version - increment when structure changes
 const WORKING_CONTEXT_VERSION = 1;
@@ -138,7 +138,8 @@ function clearStoredWorkingContext(projectId: string): void {
 const WorkingContext = React.createContext<WorkingContextValue | null>(null);
 
 export function WorkingContextProvider({ children }: { children: React.ReactNode }) {
-  const { activeProject } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const activeProject = activeProjectContext?.activeProject ?? null;
   const activeProjectId = activeProject?.id ?? null;
 
   // Current working context (for active project)

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -34,7 +34,7 @@ import { DashboardLayout } from '@/components/templates/DashboardLayout';
 import { Card, CardHeader, CardTitle, CardContent, Badge, Button } from '@/components/ui';
 import { useAuth } from '@/contexts/AuthContext';
 import { useNotifications, Notification, NotificationType, NotificationPriority } from '@/contexts/NotificationContext';
-import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '@/contexts/ActiveProjectContext';
 import { cn } from '@/lib/utils';
 
 // Notification type icons
@@ -243,7 +243,9 @@ function NotificationItem({
 export default function Notifications() {
   const { user } = useAuth();
   const navigate = useNavigate();
-  const { activeProject, hasFocus } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const activeProject = activeProjectContext?.activeProject ?? null;
+  const hasFocus = activeProjectContext?.hasFocus ?? false;
   const {
     state,
     fetchNotifications,

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -69,7 +69,7 @@ import { useTaskRealtime } from '@/hooks/useTaskRealtime';
 import { useAssets, AssetRecord } from '@/contexts/AssetsContext';
 import { AssetDetailDrawer } from '@/components/assets/AssetDetailDrawer';
 import { useProjectCounts } from '@/hooks/useProjectCounts';
-import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '@/contexts/ActiveProjectContext';
 import { cn } from '@/lib/utils';
 import { toast } from '@/lib/toast';
 
@@ -196,7 +196,9 @@ export const ProjectDetail = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
   const { projects, loading: projectsLoading } = useProjects();
-  const { setActiveProject, isProjectFocused } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const setActiveProject = activeProjectContext?.setActiveProject ?? (() => {});
+  const isProjectFocused = activeProjectContext?.isProjectFocused ?? (() => false);
 
   // ============================================================================
   // State Management

--- a/src/pages/ProjectsNew.tsx
+++ b/src/pages/ProjectsNew.tsx
@@ -20,7 +20,7 @@ import { useProjects, Project } from '../hooks/useProjects';
 import { useTeams } from '../hooks/useTeams';
 import { useOrganizations } from '../hooks/useOrganizations';
 import { useConnectors } from '../contexts/ConnectorsContext';
-import { useActiveProject } from '../contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '../contexts/ActiveProjectContext';
 import { toast } from '../lib/toast';
 import {
   Plus,
@@ -45,7 +45,10 @@ export function ProjectsNew() {
   const { projects, loading, error, createProject } = useProjects();
   const { teams } = useTeams();
   const { currentOrganization } = useOrganizations();
-  const { activeProject, setActiveProject, isProjectFocused } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const activeProject = activeProjectContext?.activeProject ?? null;
+  const setActiveProject = activeProjectContext?.setActiveProject ?? (() => {});
+  const isProjectFocused = activeProjectContext?.isProjectFocused ?? (() => false);
 
   // Try to get connectors context for file linking
   let linkFileToProject: ((fileId: string, projectId: string) => Promise<void>) | undefined;

--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -11,7 +11,7 @@ import { DashboardLayout } from '@/components/templates';
 import { Card, Button, Badge } from '@/components/ui';
 import { useAuth } from '../contexts/AuthContext';
 import { useMetMap } from '../contexts/MetMapContext';
-import { useActiveProject } from '../contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '../contexts/ActiveProjectContext';
 import {
   Map,
   ExternalLink,
@@ -104,7 +104,9 @@ function Tools() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const { stats, loadStats } = useMetMap();
-  const { activeProject, hasFocus } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const activeProject = activeProjectContext?.activeProject ?? null;
+  const hasFocus = activeProjectContext?.hasFocus ?? false;
 
   // Authentication guard - redirect to login if not authenticated
   React.useEffect(() => {


### PR DESCRIPTION
Convert all useActiveProject() calls to useActiveProjectOptional() to prevent crashes during 401 race conditions. Components now safely handle missing context during auth transitions.

Updated files:
- ProjectContextBar: Safe access with fallback noop for clearActiveProject
- QuickActions: Safe access for activeProject and hasFocus
- PulsePanel: Safe access for activeProject
- WorkingContext: Safe access in context provider
- Notifications: Safe access with fallbacks for filtering
- ProjectDetail: Safe access for setActiveProject and isProjectFocused
- ProjectsNew: Safe access for project management
- Tools: Safe access for hasFocus check

This ensures no component throws during the brief window between 401 detection and redirect to login.