### PR TITLE
fix(hooks): Convert remaining hooks to use optional context

### DIFF
--- a/src/hooks/useProjectPresence.ts
+++ b/src/hooks/useProjectPresence.ts
@@ -13,7 +13,7 @@
 
 import * as React from 'react';
 import { socketService, ProjectPresenceMember, PulseEvent } from '@/services/socketService';
-import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '@/contexts/ActiveProjectContext';
 import { useAuth } from '@/contexts/AuthContext';
 
 export interface ProjectPresenceState {
@@ -33,7 +33,9 @@ export interface UseProjectPresenceReturn extends ProjectPresenceState {
 }
 
 export function useProjectPresence(): UseProjectPresenceReturn {
-  const { activeProject, hasFocus } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const activeProject = activeProjectContext?.activeProject ?? null;
+  const hasFocus = activeProjectContext?.hasFocus ?? false;
   const { user } = useAuth();
 
   const [members, setMembers] = React.useState<ProjectPresenceMember[]>([]);

--- a/src/hooks/useProjectPulse.ts
+++ b/src/hooks/useProjectPulse.ts
@@ -11,7 +11,7 @@
  */
 
 import * as React from 'react';
-import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '@/contexts/ActiveProjectContext';
 import { useSession } from '@/contexts/SessionContext';
 import { useNotifications, Notification } from '@/contexts/NotificationContext';
 import { useTasks, Task } from '@/hooks/useTasks';
@@ -88,7 +88,9 @@ export interface UseProjectPulseReturn extends ProjectPulseState {
 }
 
 export function useProjectPulse(): UseProjectPulseReturn {
-  const { activeProject, hasFocus } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const activeProject = activeProjectContext?.activeProject ?? null;
+  const hasFocus = activeProjectContext?.hasFocus ?? false;
   const { session, markAsSeen, getTimeSinceLastSeen } = useSession();
   const { state: notificationState } = useNotifications();
   const { tasks } = useTasks(activeProject?.id);

--- a/src/hooks/useUserTestMode.ts
+++ b/src/hooks/useUserTestMode.ts
@@ -8,7 +8,7 @@
 import * as React from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
-import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '@/contexts/ActiveProjectContext';
 import {
   userTestLogger,
   TesterInfo,
@@ -60,7 +60,8 @@ export function useUserTestMode(): UseUserTestModeReturn {
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const { user } = useAuth();
-  const { activeProject } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const activeProject = activeProjectContext?.activeProject ?? null;
 
   const [isEnabled, setIsEnabled] = React.useState(() => userTestLogger.isTestModeEnabled());
   const [testerInfo, setTesterInfo] = React.useState<TesterInfo | null>(() => userTestLogger.getTesterInfo());

--- a/src/hooks/useWorkMomentumCapture.ts
+++ b/src/hooks/useWorkMomentumCapture.ts
@@ -13,7 +13,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 import { useWorkingContextOptional, LastEntity } from '../contexts/WorkingContext';
-import { useActiveProject } from '../contexts/ActiveProjectContext';
+import { useActiveProjectOptional } from '../contexts/ActiveProjectContext';
 
 // Routes that are considered "project-scoped" for context capture
 const PROJECT_SCOPED_ROUTES = [
@@ -88,7 +88,9 @@ export function useWorkMomentumCapture(options: UseWorkMomentumCaptureOptions = 
   const { entityOverrides, disabled = false } = options;
   const location = useLocation();
   const workingContext = useWorkingContextOptional();
-  const { hasFocus, activeProject } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const hasFocus = activeProjectContext?.hasFocus ?? false;
+  const activeProject = activeProjectContext?.activeProject ?? null;
 
   // Debounce timer ref
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
@@ -173,7 +175,8 @@ export function useWorkMomentumCapture(options: UseWorkMomentumCaptureOptions = 
  */
 export function useReportEntityFocus() {
   const workingContext = useWorkingContextOptional();
-  const { hasFocus } = useActiveProject();
+  const activeProjectContext = useActiveProjectOptional();
+  const hasFocus = activeProjectContext?.hasFocus ?? false;
 
   const reportConversation = useCallback(
     (conversationId: string, messageId?: string) => {


### PR DESCRIPTION
Fix additional hooks that were still using the throwing useActiveProject():
- useProjectPulse.ts: Safe access for pulse data
- useProjectPresence.ts: Safe access for presence tracking
- useUserTestMode.ts: Safe access for test mode
- useWorkMomentumCapture.ts: Safe access in both exported functions

This completes the migration to useActiveProjectOptional() across the entire codebase, ensuring no component or hook can crash during 401 auth transitions.