### PR TITLE
fix(context): Add useFilesOptional hook and update consumers

### DIFF
--- a/src/components/assets/AssetDetailDrawer.tsx
+++ b/src/components/assets/AssetDetailDrawer.tsx
@@ -9,7 +9,7 @@
 
 import * as React from 'react';
 import { useAssets, AssetRecord, AssetVersion, AssetRelation, AssetMetadata, AssetTag, AssetComment, RelationType } from '../../contexts/AssetsContext';
-import { useFiles } from '../../contexts/FilesContext';
+import { useFilesOptional } from '../../contexts/FilesContext';
 import { useNotifications } from '../../contexts/NotificationContext';
 
 // Asset type config
@@ -77,7 +77,9 @@ export function AssetDetailDrawer({ asset, onClose, onDelete }: AssetDetailDrawe
     resolveComment,
     updateAsset
   } = useAssets();
-  const { state: filesState, uploadFiles } = useFiles();
+  const filesContext = useFilesOptional();
+  const filesState = filesContext?.state;
+  const uploadFiles = filesContext?.uploadFiles ?? (async () => []);
   const { addNotification } = useNotifications();
 
   // State

--- a/src/contexts/FilesContext.tsx
+++ b/src/contexts/FilesContext.tsx
@@ -596,4 +596,10 @@ export function useFiles(): FilesContextValue {
   return context;
 }
 
+// ==================== Optional Hook ====================
+
+export function useFilesOptional(): FilesContextValue | null {
+  return React.useContext(FilesContext);
+}
+
 export default FilesContext;

--- a/src/pages/Assets.tsx
+++ b/src/pages/Assets.tsx
@@ -20,7 +20,7 @@ import * as React from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import DashboardLayout from '../components/layout/DashboardLayout';
 import { useAssets, AssetRecord, AssetType } from '../contexts/AssetsContext';
-import { useFiles } from '../contexts/FilesContext';
+import { useFilesOptional } from '../contexts/FilesContext';
 import { useNotifications } from '../contexts/NotificationContext';
 import { AssetDetailDrawer } from '../components/assets/AssetDetailDrawer';
 import { useReportEntityFocus } from '../hooks/useWorkMomentumCapture';
@@ -226,7 +226,8 @@ export default function Assets() {
     deleteAsset,
     getAssetById
   } = useAssets();
-  const { state: filesState } = useFiles();
+  const filesContext = useFilesOptional();
+  const filesState = filesContext?.state ?? { files: [], loading: false, error: null, filters: { search: '', type: 'all', source: 'all' }, pagination: { page: 1, pageSize: 20, total: 0, totalPages: 0 }, selectedFile: null, uploadProgress: {}, stats: null };
   const { addNotification } = useNotifications();
   const { reportAsset } = useReportEntityFocus();
 

--- a/src/pages/FileNew.tsx
+++ b/src/pages/FileNew.tsx
@@ -19,7 +19,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { DashboardLayout } from '../components/templates';
 import { Button, Badge, Dialog, DialogContent, DialogHeader, DialogTitle, Input, Card, CardContent } from '../components/ui';
 import { useAuth } from '../contexts/AuthContext';
-import { useFiles, FileRecord, FileType, FileSource } from '../contexts/FilesContext';
+import { useFilesOptional, FileRecord, FileType, FileSource } from '../contexts/FilesContext';
 import { useProjects } from '../hooks/useProjects';
 import { useReportEntityFocus } from '../hooks/useWorkMomentumCapture';
 import { toast } from '../lib/toast';
@@ -347,6 +347,15 @@ export function FileNew() {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const filesContext = useFilesOptional();
+  const { projects } = useProjects();
+  const { reportFile } = useReportEntityFocus();
+
+  // Guard: If context not available, return null (handled by ProtectedRoute)
+  if (!filesContext || !user) {
+    return null;
+  }
+
   const {
     state,
     refreshFiles,
@@ -357,9 +366,7 @@ export function FileNew() {
     setFilters,
     setPage,
     setSelectedFile
-  } = useFiles();
-  const { projects } = useProjects();
-  const { reportFile } = useReportEntityFocus();
+  } = filesContext;
 
   // UI State
   const [viewMode, setViewMode] = React.useState<ViewMode>('grid');


### PR DESCRIPTION
Fix useFiles context crash during 401 auth transitions:
- Add useFilesOptional() hook to FilesContext
- Update FileNew.tsx to use optional hook with guard
- Update Assets.tsx to use optional hook with fallback state
- Update AssetDetailDrawer.tsx to use optional hook with fallbacks

This prevents the "useFiles must be used within FilesProvider" crash that occurs when components render during auth state transitions.