### PR TITLE
fix(auth): Also handle 403 with auth messages as auth error

### DIFF
--- a/src/services/apiService.ts
+++ b/src/services/apiService.ts
@@ -186,8 +186,14 @@ class ApiService {
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
 
-        // Handle authentication errors - 401 Unauthorized
-        if (response.status === 401) {
+        // Handle authentication errors - 401 Unauthorized or 403 with auth message
+        if (response.status === 401 ||
+            (response.status === 403 && (
+              errorData.message?.toLowerCase().includes('token') ||
+              errorData.message?.toLowerCase().includes('unauthorized') ||
+              errorData.message?.toLowerCase().includes('authentication') ||
+              errorData.error === 'INVALID_TOKEN'
+            ))) {
           this.handleAuthError();
           throw new Error('Authentication required. Please sign in again.');
         }


### PR DESCRIPTION
The /api/auth/me endpoint returns 403 with "Invalid or expired token" message instead of 401. Update the auth error detection to also catch 403 responses that contain auth-related error messages (token, unauthorized, authentication) to properly trigger login redirect.