### PR TITLE
feat(messaging): add presence indicators, read receipts, and summary …

### DIFF
--- a/src/components/messaging/ConversationSummary.tsx
+++ b/src/components/messaging/ConversationSummary.tsx
@@ -1,0 +1,409 @@
+/**
+ * ConversationSummary Component
+ *
+ * Displays a summary of a conversation including:
+ * - Auto-generated summary text (placeholder for AI integration)
+ * - Key decisions made in the conversation
+ * - Open questions / action items
+ * - Participant activity overview
+ *
+ * This is a scaffold for future AI-powered summaries.
+ *
+ * Usage:
+ * <ConversationSummary
+ *   conversationId={conversationId}
+ *   summary={summaryData}
+ *   onClose={() => setShowSummary(false)}
+ * />
+ */
+
+import * as React from 'react';
+import {
+  X,
+  Sparkles,
+  CheckCircle2,
+  HelpCircle,
+  Users,
+  Clock,
+  RefreshCw,
+  AlertCircle,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface KeyDecision {
+  id: string;
+  text: string;
+  decidedBy?: string;
+  timestamp?: Date;
+}
+
+interface OpenQuestion {
+  id: string;
+  text: string;
+  askedBy?: string;
+  timestamp?: Date;
+}
+
+interface ParticipantActivity {
+  userId: string;
+  name: string;
+  avatar?: string;
+  messageCount: number;
+  lastActive?: Date;
+}
+
+export interface ConversationSummaryData {
+  /** AI-generated or extracted summary text */
+  summaryText?: string;
+  /** Key decisions made in conversation */
+  keyDecisions?: KeyDecision[];
+  /** Open questions that need answers */
+  openQuestions?: OpenQuestion[];
+  /** Participant activity stats */
+  participantActivity?: ParticipantActivity[];
+  /** When the summary was last generated */
+  generatedAt?: Date;
+  /** Whether summary is currently being generated */
+  isGenerating?: boolean;
+  /** Error if summary generation failed */
+  error?: string;
+}
+
+interface ConversationSummaryProps {
+  /** Conversation ID */
+  conversationId: string;
+  /** Summary data */
+  summary?: ConversationSummaryData;
+  /** Whether the panel is loading */
+  isLoading?: boolean;
+  /** Callback when panel is closed */
+  onClose: () => void;
+  /** Callback to refresh/regenerate summary */
+  onRefresh?: () => void;
+  /** Additional class name */
+  className?: string;
+}
+
+// ============================================================================
+// Helper Components
+// ============================================================================
+
+function SectionHeader({
+  icon: Icon,
+  title,
+  count,
+  isExpanded,
+  onToggle,
+}: {
+  icon: React.ElementType;
+  title: string;
+  count?: number;
+  isExpanded?: boolean;
+  onToggle?: () => void;
+}) {
+  return (
+    <button
+      onClick={onToggle}
+      className={cn(
+        'w-full flex items-center gap-2 px-3 py-2 rounded-lg',
+        'text-sm font-medium text-neutral-700 dark:text-neutral-300',
+        'hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors',
+        onToggle && 'cursor-pointer'
+      )}
+    >
+      <Icon className="w-4 h-4 text-neutral-500" />
+      <span className="flex-1 text-left">{title}</span>
+      {count !== undefined && (
+        <span className="text-xs bg-neutral-200 dark:bg-neutral-700 px-1.5 py-0.5 rounded">
+          {count}
+        </span>
+      )}
+      {onToggle && (
+        isExpanded ? (
+          <ChevronUp className="w-4 h-4 text-neutral-400" />
+        ) : (
+          <ChevronDown className="w-4 h-4 text-neutral-400" />
+        )
+      )}
+    </button>
+  );
+}
+
+function EmptySummaryState({ onGenerate }: { onGenerate?: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-8 px-4 text-center">
+      <div className="w-12 h-12 rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center mb-4">
+        <Sparkles className="w-6 h-6 text-primary-600 dark:text-primary-400" />
+      </div>
+      <h4 className="text-sm font-medium text-neutral-900 dark:text-neutral-100 mb-1">
+        No Summary Yet
+      </h4>
+      <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-4 max-w-[200px]">
+        Summary generation will be available in a future update.
+      </p>
+      {onGenerate && (
+        <button
+          onClick={onGenerate}
+          disabled
+          className={cn(
+            'flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium',
+            'bg-primary-600 text-white',
+            'opacity-50 cursor-not-allowed'
+          )}
+        >
+          <Sparkles className="w-4 h-4" />
+          Generate Summary
+        </button>
+      )}
+    </div>
+  );
+}
+
+function GeneratingState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-8 px-4 text-center">
+      <div className="w-12 h-12 rounded-full bg-primary-100 dark:bg-primary-900/30 flex items-center justify-center mb-4 animate-pulse">
+        <RefreshCw className="w-6 h-6 text-primary-600 dark:text-primary-400 animate-spin" />
+      </div>
+      <h4 className="text-sm font-medium text-neutral-900 dark:text-neutral-100 mb-1">
+        Generating Summary...
+      </h4>
+      <p className="text-xs text-neutral-500 dark:text-neutral-400">
+        Analyzing conversation content
+      </p>
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function ConversationSummary({
+  conversationId,
+  summary,
+  isLoading,
+  onClose,
+  onRefresh,
+  className,
+}: ConversationSummaryProps) {
+  const [decisionsExpanded, setDecisionsExpanded] = React.useState(true);
+  const [questionsExpanded, setQuestionsExpanded] = React.useState(true);
+  const [activityExpanded, setActivityExpanded] = React.useState(false);
+
+  const hasContent = summary && (
+    summary.summaryText ||
+    (summary.keyDecisions && summary.keyDecisions.length > 0) ||
+    (summary.openQuestions && summary.openQuestions.length > 0)
+  );
+
+  return (
+    <div
+      className={cn(
+        'w-80 flex flex-col h-full',
+        'bg-white dark:bg-neutral-900',
+        'border-l border-neutral-200 dark:border-neutral-700',
+        className
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-neutral-200 dark:border-neutral-700">
+        <div className="flex items-center gap-2">
+          <Sparkles className="w-4 h-4 text-primary-600" />
+          <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
+            Summary
+          </h3>
+        </div>
+        <div className="flex items-center gap-1">
+          {onRefresh && hasContent && (
+            <button
+              onClick={onRefresh}
+              disabled={summary?.isGenerating}
+              className={cn(
+                'p-1.5 rounded-lg transition-colors',
+                'hover:bg-neutral-100 dark:hover:bg-neutral-800',
+                'text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300',
+                summary?.isGenerating && 'opacity-50 cursor-not-allowed'
+              )}
+              title="Refresh summary"
+            >
+              <RefreshCw className={cn('w-4 h-4', summary?.isGenerating && 'animate-spin')} />
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 transition-colors"
+            title="Close summary"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        {isLoading ? (
+          <GeneratingState />
+        ) : summary?.isGenerating ? (
+          <GeneratingState />
+        ) : summary?.error ? (
+          <div className="p-4 text-center">
+            <AlertCircle className="w-8 h-8 text-red-500 mx-auto mb-2" />
+            <p className="text-sm text-red-600 dark:text-red-400">{summary.error}</p>
+          </div>
+        ) : !hasContent ? (
+          <EmptySummaryState onGenerate={onRefresh} />
+        ) : (
+          <div className="p-3 space-y-4">
+            {/* Summary Text */}
+            {summary?.summaryText && (
+              <div className="p-3 bg-neutral-50 dark:bg-neutral-800 rounded-lg">
+                <p className="text-sm text-neutral-700 dark:text-neutral-300 leading-relaxed">
+                  {summary.summaryText}
+                </p>
+                {summary.generatedAt && (
+                  <p className="text-[10px] text-neutral-400 mt-2">
+                    Generated {formatRelativeTime(summary.generatedAt)}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Key Decisions */}
+            {summary?.keyDecisions && summary.keyDecisions.length > 0 && (
+              <div>
+                <SectionHeader
+                  icon={CheckCircle2}
+                  title="Key Decisions"
+                  count={summary.keyDecisions.length}
+                  isExpanded={decisionsExpanded}
+                  onToggle={() => setDecisionsExpanded(!decisionsExpanded)}
+                />
+                {decisionsExpanded && (
+                  <ul className="mt-2 space-y-2 pl-2">
+                    {summary.keyDecisions.map((decision) => (
+                      <li
+                        key={decision.id}
+                        className="flex gap-2 text-sm text-neutral-600 dark:text-neutral-400"
+                      >
+                        <CheckCircle2 className="w-4 h-4 text-green-500 flex-shrink-0 mt-0.5" />
+                        <span>{decision.text}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {/* Open Questions */}
+            {summary?.openQuestions && summary.openQuestions.length > 0 && (
+              <div>
+                <SectionHeader
+                  icon={HelpCircle}
+                  title="Open Questions"
+                  count={summary.openQuestions.length}
+                  isExpanded={questionsExpanded}
+                  onToggle={() => setQuestionsExpanded(!questionsExpanded)}
+                />
+                {questionsExpanded && (
+                  <ul className="mt-2 space-y-2 pl-2">
+                    {summary.openQuestions.map((question) => (
+                      <li
+                        key={question.id}
+                        className="flex gap-2 text-sm text-neutral-600 dark:text-neutral-400"
+                      >
+                        <HelpCircle className="w-4 h-4 text-amber-500 flex-shrink-0 mt-0.5" />
+                        <span>{question.text}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+
+            {/* Participant Activity */}
+            {summary?.participantActivity && summary.participantActivity.length > 0 && (
+              <div>
+                <SectionHeader
+                  icon={Users}
+                  title="Participant Activity"
+                  count={summary.participantActivity.length}
+                  isExpanded={activityExpanded}
+                  onToggle={() => setActivityExpanded(!activityExpanded)}
+                />
+                {activityExpanded && (
+                  <ul className="mt-2 space-y-2">
+                    {summary.participantActivity.map((participant) => (
+                      <li
+                        key={participant.userId}
+                        className="flex items-center gap-3 px-2 py-1.5 rounded-lg hover:bg-neutral-50 dark:hover:bg-neutral-800"
+                      >
+                        {participant.avatar ? (
+                          <img
+                            src={participant.avatar}
+                            alt={participant.name}
+                            className="w-6 h-6 rounded-full"
+                          />
+                        ) : (
+                          <div className="w-6 h-6 rounded-full bg-primary-100 dark:bg-primary-900 flex items-center justify-center">
+                            <span className="text-xs font-medium text-primary-600 dark:text-primary-400">
+                              {participant.name.charAt(0).toUpperCase()}
+                            </span>
+                          </div>
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-neutral-900 dark:text-neutral-100 truncate">
+                            {participant.name}
+                          </p>
+                          <p className="text-xs text-neutral-500">
+                            {participant.messageCount} messages
+                          </p>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Footer with timestamp */}
+      {hasContent && summary?.generatedAt && (
+        <div className="px-4 py-2 border-t border-neutral-200 dark:border-neutral-700">
+          <p className="text-[10px] text-neutral-400 flex items-center gap-1">
+            <Clock className="w-3 h-3" />
+            Last updated {formatRelativeTime(summary.generatedAt)}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+export default ConversationSummary;

--- a/src/components/messaging/PresenceIndicator.tsx
+++ b/src/components/messaging/PresenceIndicator.tsx
@@ -1,0 +1,248 @@
+/**
+ * PresenceIndicator Component
+ *
+ * Displays user presence status with "Online" or "Last seen X ago".
+ * Uses real-time socket updates when available.
+ *
+ * Features:
+ * - Green dot + "Online" for active users
+ * - "Last seen X min ago" for inactive users
+ * - Typing indicator integration
+ * - Lightweight, uses existing socket infrastructure
+ */
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type PresenceStatus = 'online' | 'away' | 'busy' | 'offline';
+
+interface PresenceIndicatorProps {
+  /** User's current status */
+  status: PresenceStatus;
+  /** Last seen timestamp (ISO string) */
+  lastSeen?: string | Date;
+  /** Whether user is currently typing */
+  isTyping?: boolean;
+  /** Show status dot only (no text) */
+  dotOnly?: boolean;
+  /** Size variant */
+  size?: 'sm' | 'md' | 'lg';
+  /** Custom class name */
+  className?: string;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function formatLastSeen(lastSeen?: string | Date): string {
+  if (!lastSeen) return 'Offline';
+
+  const date = typeof lastSeen === 'string' ? new Date(lastSeen) : lastSeen;
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffMins < 1) return 'Active just now';
+  if (diffMins < 2) return 'Active 1 min ago';
+  if (diffMins < 60) return `Active ${diffMins} min ago`;
+  if (diffHours < 2) return 'Active 1 hour ago';
+  if (diffHours < 24) return `Active ${diffHours} hours ago`;
+  if (diffDays < 2) return 'Active yesterday';
+  if (diffDays < 7) return `Active ${diffDays} days ago`;
+  return `Last seen ${date.toLocaleDateString()}`;
+}
+
+function getStatusColor(status: PresenceStatus): string {
+  switch (status) {
+    case 'online':
+      return 'bg-green-500';
+    case 'away':
+      return 'bg-yellow-500';
+    case 'busy':
+      return 'bg-red-500';
+    case 'offline':
+    default:
+      return 'bg-neutral-400 dark:bg-neutral-600';
+  }
+}
+
+function getStatusText(status: PresenceStatus, lastSeen?: string | Date): string {
+  switch (status) {
+    case 'online':
+      return 'Online';
+    case 'away':
+      return 'Away';
+    case 'busy':
+      return 'Busy';
+    case 'offline':
+    default:
+      return formatLastSeen(lastSeen);
+  }
+}
+
+// ============================================================================
+// Status Dot Component
+// ============================================================================
+
+export function StatusDot({
+  status,
+  size = 'sm',
+  className,
+}: {
+  status: PresenceStatus;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}) {
+  const sizeClasses = {
+    sm: 'w-2 h-2',
+    md: 'w-2.5 h-2.5',
+    lg: 'w-3 h-3',
+  };
+
+  return (
+    <span
+      className={cn(
+        'rounded-full ring-2 ring-white dark:ring-neutral-900',
+        getStatusColor(status),
+        sizeClasses[size],
+        className
+      )}
+      aria-hidden="true"
+    />
+  );
+}
+
+// ============================================================================
+// Typing Indicator
+// ============================================================================
+
+export function TypingIndicator({ className }: { className?: string }) {
+  return (
+    <span className={cn('flex items-center gap-0.5', className)}>
+      <span className="text-primary-600 dark:text-primary-400 text-xs italic">
+        typing
+      </span>
+      <span className="flex gap-0.5 ml-0.5">
+        {[0, 1, 2].map((i) => (
+          <span
+            key={i}
+            className="w-1 h-1 bg-primary-500 rounded-full animate-bounce"
+            style={{ animationDelay: `${i * 150}ms` }}
+          />
+        ))}
+      </span>
+    </span>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function PresenceIndicator({
+  status,
+  lastSeen,
+  isTyping = false,
+  dotOnly = false,
+  size = 'sm',
+  className,
+}: PresenceIndicatorProps) {
+  // If typing, show typing indicator
+  if (isTyping) {
+    return <TypingIndicator className={className} />;
+  }
+
+  // Dot only mode
+  if (dotOnly) {
+    return <StatusDot status={status} size={size} className={className} />;
+  }
+
+  // Full indicator with text
+  const textSizeClasses = {
+    sm: 'text-xs',
+    md: 'text-sm',
+    lg: 'text-base',
+  };
+
+  const statusText = getStatusText(status, lastSeen);
+  const isOnline = status === 'online';
+
+  return (
+    <span
+      className={cn(
+        'flex items-center gap-1.5',
+        textSizeClasses[size],
+        className
+      )}
+    >
+      <StatusDot status={status} size={size} />
+      <span
+        className={cn(
+          isOnline
+            ? 'text-green-600 dark:text-green-400'
+            : 'text-neutral-500 dark:text-neutral-400'
+        )}
+      >
+        {statusText}
+      </span>
+    </span>
+  );
+}
+
+// ============================================================================
+// Conversation Header Presence
+// ============================================================================
+
+export function ConversationHeaderPresence({
+  isOnline,
+  lastSeen,
+  isTyping,
+  memberCount,
+  isGroup = false,
+  className,
+}: {
+  isOnline?: boolean;
+  lastSeen?: string | Date;
+  isTyping?: boolean;
+  memberCount?: number;
+  isGroup?: boolean;
+  className?: string;
+}) {
+  // Group conversations
+  if (isGroup && memberCount) {
+    return (
+      <span className={cn('text-xs text-neutral-500 dark:text-neutral-400', className)}>
+        {memberCount} members
+        {isTyping && (
+          <>
+            {' · '}
+            <TypingIndicator />
+          </>
+        )}
+      </span>
+    );
+  }
+
+  // Direct messages
+  if (isTyping) {
+    return <TypingIndicator className={className} />;
+  }
+
+  return (
+    <PresenceIndicator
+      status={isOnline ? 'online' : 'offline'}
+      lastSeen={lastSeen}
+      size="sm"
+      className={className}
+    />
+  );
+}
+
+export default PresenceIndicator;

--- a/src/components/messaging/ReadReceiptIndicator.tsx
+++ b/src/components/messaging/ReadReceiptIndicator.tsx
@@ -1,0 +1,271 @@
+/**
+ * ReadReceiptIndicator Component
+ *
+ * Displays "Seen by X" or avatar stacks for read receipts on messages.
+ * Minimal, non-intrusive design that shows who has seen the message.
+ *
+ * Features:
+ * - Avatar stack for multiple viewers
+ * - "Seen by X" text for single viewers
+ * - Hover tooltip with full list
+ * - Only shows on last message from sender
+ */
+
+import * as React from 'react';
+import { Check, CheckCheck } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ReadReceiptUser {
+  id: string;
+  name: string;
+  avatar?: string;
+  readAt?: string;
+}
+
+interface ReadReceiptIndicatorProps {
+  /** Users who have read this message */
+  readBy: ReadReceiptUser[];
+  /** Current user ID (to exclude from display) */
+  currentUserId: string;
+  /** Whether this is the sender's own message */
+  isOwnMessage: boolean;
+  /** Message status (for delivery indicators) */
+  status?: 'sending' | 'sent' | 'delivered' | 'read' | 'failed';
+  /** Optional class name */
+  className?: string;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map(n => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function formatReadTime(dateString?: string): string {
+  if (!dateString) return '';
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / (1000 * 60));
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return date.toLocaleDateString();
+}
+
+// ============================================================================
+// Mini Avatar Component
+// ============================================================================
+
+function MiniAvatar({
+  user,
+  size = 'sm',
+}: {
+  user: ReadReceiptUser;
+  size?: 'xs' | 'sm';
+}) {
+  const sizeClasses = {
+    xs: 'w-4 h-4 text-[8px]',
+    sm: 'w-5 h-5 text-[9px]',
+  };
+
+  return (
+    <div
+      className={cn(
+        'rounded-full bg-neutral-200 dark:bg-neutral-700 flex items-center justify-center ring-1 ring-white dark:ring-neutral-900 overflow-hidden',
+        sizeClasses[size]
+      )}
+      title={`Seen by ${user.name}`}
+    >
+      {user.avatar ? (
+        <img
+          src={user.avatar}
+          alt={user.name}
+          className="w-full h-full object-cover"
+        />
+      ) : (
+        <span className="font-medium text-neutral-600 dark:text-neutral-300">
+          {getInitials(user.name)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Avatar Stack Component
+// ============================================================================
+
+function AvatarStack({
+  users,
+  maxVisible = 3,
+}: {
+  users: ReadReceiptUser[];
+  maxVisible?: number;
+}) {
+  const visibleUsers = users.slice(0, maxVisible);
+  const remainingCount = users.length - maxVisible;
+
+  return (
+    <div className="flex -space-x-1.5">
+      {visibleUsers.map((user) => (
+        <MiniAvatar key={user.id} user={user} size="xs" />
+      ))}
+      {remainingCount > 0 && (
+        <div
+          className="w-4 h-4 rounded-full bg-neutral-300 dark:bg-neutral-600 flex items-center justify-center text-[8px] font-medium text-neutral-700 dark:text-neutral-300 ring-1 ring-white dark:ring-neutral-900"
+          title={`+${remainingCount} more`}
+        >
+          +{remainingCount}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function ReadReceiptIndicator({
+  readBy,
+  currentUserId,
+  isOwnMessage,
+  status = 'sent',
+  className,
+}: ReadReceiptIndicatorProps) {
+  const [showTooltip, setShowTooltip] = React.useState(false);
+
+  // Filter out current user from read receipts
+  const otherReaders = readBy.filter(u => u.id !== currentUserId);
+
+  // If this is not the sender's message, don't show read receipts
+  if (!isOwnMessage) {
+    return null;
+  }
+
+  // For own messages, show delivery/read status
+  if (otherReaders.length === 0) {
+    // No readers yet, show delivery status
+    return (
+      <div className={cn('flex items-center gap-1 text-xs', className)}>
+        {status === 'sending' && (
+          <span className="text-neutral-400">Sending...</span>
+        )}
+        {status === 'sent' && (
+          <Check className="w-3.5 h-3.5 text-neutral-400" />
+        )}
+        {status === 'delivered' && (
+          <CheckCheck className="w-3.5 h-3.5 text-neutral-400" />
+        )}
+        {status === 'failed' && (
+          <span className="text-red-500">Failed</span>
+        )}
+      </div>
+    );
+  }
+
+  // Show "Seen" with avatar(s)
+  return (
+    <div
+      className={cn(
+        'relative flex items-center gap-1.5 text-xs text-neutral-500 dark:text-neutral-400',
+        className
+      )}
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
+      <CheckCheck className="w-3.5 h-3.5 text-primary-500" />
+
+      {otherReaders.length === 1 ? (
+        // Single reader: show name
+        <span>Seen by {otherReaders[0].name.split(' ')[0]}</span>
+      ) : otherReaders.length <= 3 ? (
+        // 2-3 readers: show avatar stack + count
+        <div className="flex items-center gap-1">
+          <AvatarStack users={otherReaders} maxVisible={3} />
+          <span>Seen by {otherReaders.length}</span>
+        </div>
+      ) : (
+        // Many readers: show avatar stack + "Seen by X"
+        <div className="flex items-center gap-1">
+          <AvatarStack users={otherReaders} maxVisible={3} />
+          <span>Seen by {otherReaders.length}</span>
+        </div>
+      )}
+
+      {/* Tooltip with full reader list */}
+      {showTooltip && otherReaders.length > 1 && (
+        <div className="absolute bottom-full left-0 mb-1 p-2 bg-neutral-900 dark:bg-neutral-800 rounded-lg shadow-lg z-50 min-w-[160px] max-w-[240px]">
+          <p className="text-xs font-medium text-white mb-1.5">
+            Seen by {otherReaders.length}
+          </p>
+          <div className="space-y-1">
+            {otherReaders.slice(0, 10).map(user => (
+              <div key={user.id} className="flex items-center gap-2">
+                <MiniAvatar user={user} size="xs" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-xs text-neutral-200 truncate">{user.name}</p>
+                  {user.readAt && (
+                    <p className="text-[10px] text-neutral-400">
+                      {formatReadTime(user.readAt)}
+                    </p>
+                  )}
+                </div>
+              </div>
+            ))}
+            {otherReaders.length > 10 && (
+              <p className="text-[10px] text-neutral-400 mt-1">
+                +{otherReaders.length - 10} more
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Compact Read Receipt (for message list items)
+// ============================================================================
+
+export function CompactReadReceipt({
+  isRead,
+  readCount,
+  className,
+}: {
+  isRead: boolean;
+  readCount?: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn('flex items-center gap-0.5', className)}>
+      {isRead ? (
+        <>
+          <CheckCheck className="w-3 h-3 text-primary-500" />
+          {readCount && readCount > 0 && (
+            <span className="text-[10px] text-neutral-400">{readCount}</span>
+          )}
+        </>
+      ) : (
+        <Check className="w-3 h-3 text-neutral-400" />
+      )}
+    </div>
+  );
+}
+
+export default ReadReceiptIndicator;

--- a/src/pages/MessagesNew.tsx
+++ b/src/pages/MessagesNew.tsx
@@ -93,6 +93,8 @@ import { MessageSearchPanel } from '../components/messaging/MessageSearchPanel';
 import { MessageSearchResult } from '../hooks/useMessageSearch';
 import { MarkdownMessage } from '../components/messaging/MarkdownMessage';
 import { ThreadPanel } from '../components/messaging/ThreadPanel';
+import { ConversationHeaderPresence } from '../components/messaging/PresenceIndicator';
+import { ConversationSummary } from '../components/messaging/ConversationSummary';
 import { EmptyState, emptyStateConfigs } from '../components/common/EmptyState';
 import { useReportEntityFocus } from '../hooks/useWorkMomentumCapture';
 
@@ -1700,6 +1702,9 @@ function MessagesNew() {
   const [isLoadingThread, setIsLoadingThread] = useState(false);
   const [threadHighlightId, setThreadHighlightId] = useState<string | null>(null);
 
+  // Summary panel state
+  const [isSummaryPanelOpen, setIsSummaryPanelOpen] = useState(false);
+
   // Thread micro-hint (shown for first-time users)
   const THREAD_MICRO_HINT_KEY = 'fx_message_thread_hint_dismissed_v1';
   const [showThreadHint, setShowThreadHint] = useState<boolean>(() => {
@@ -2835,16 +2840,13 @@ function MessagesNew() {
                     <h3 className="font-semibold text-neutral-900 dark:text-neutral-100">
                       {selectedConversation.title}
                     </h3>
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                      {selectedConversation.participant.isOnline ? (
-                        <span className="text-green-600 dark:text-green-400">Online</span>
-                      ) : (
-                        'Offline'
-                      )}
-                      {selectedConversation.type === 'group' && selectedConversation.participants && (
-                        <span> · {selectedConversation.participants.length} members</span>
-                      )}
-                    </p>
+                    <ConversationHeaderPresence
+                      isOnline={selectedConversation.participant.isOnline}
+                      lastSeen={selectedConversation.participant.lastSeen}
+                      isTyping={realtime.typingUsers.some(t => t.userId === selectedConversation.participant.id)}
+                      isGroup={selectedConversation.type === 'group'}
+                      memberCount={selectedConversation.participants?.length}
+                    />
                   </div>
                 </div>
 
@@ -2868,6 +2870,13 @@ function MessagesNew() {
                     title="Pinned messages"
                   >
                     <Pin className={`w-5 h-5 ${showPinnedMessages ? 'text-accent-600' : 'text-neutral-600 dark:text-neutral-400'}`} />
+                  </button>
+                  <button
+                    onClick={() => setIsSummaryPanelOpen(!isSummaryPanelOpen)}
+                    className={`p-2 rounded-lg transition-colors ${isSummaryPanelOpen ? 'bg-primary-100 dark:bg-primary-900/30' : 'hover:bg-neutral-100 dark:hover:bg-neutral-800'}`}
+                    title="Conversation summary"
+                  >
+                    <Sparkles className={`w-5 h-5 ${isSummaryPanelOpen ? 'text-primary-600' : 'text-neutral-600 dark:text-neutral-400'}`} />
                   </button>
                   <button className="p-2 hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-lg" title="More options">
                     <MoreVertical className="w-5 h-5 text-neutral-600 dark:text-neutral-400" />
@@ -3051,6 +3060,14 @@ function MessagesNew() {
             onClose={handleCloseThread}
             onReply={handleThreadReply}
             currentUserId={user?.id}
+          />
+        )}
+
+        {/* Summary Panel */}
+        {isSummaryPanelOpen && selectedConversation && (
+          <ConversationSummary
+            conversationId={selectedConversation.id}
+            onClose={() => setIsSummaryPanelOpen(false)}
           />
         )}
       </div>


### PR DESCRIPTION
…panel

- Add PresenceIndicator component with online/away/busy/offline states
- Add ConversationHeaderPresence for conversation header with typing indicator
- Add ReadReceiptIndicator component with avatar stacks for "Seen by X"
- Add ConversationSummary panel scaffold for future AI-powered summaries
- Wire up presence indicator in conversation header replacing static Online/Offline text
- Add summary panel button and render ConversationSummary alongside ThreadPanel

These components complete the "alive" messaging experience scaffolding:
- Presence: Shows real-time online status and typing in header
- Read receipts: Infrastructure for displaying who has seen messages
- Summary: Placeholder for key decisions and open questions