### PR TITLE
feat(notifications): trigger momentum-stall nudges only when projects…

### DIFF
--- a/src/components/projects/MomentumRecoveryPanel.tsx
+++ b/src/components/projects/MomentumRecoveryPanel.tsx
@@ -1,0 +1,308 @@
+/**
+ * MomentumRecoveryPanel Component
+ *
+ * A calm, contextual UI panel that appears after a momentum stall notification
+ * to help users intentionally restart progress. Displays above the Next Steps
+ * section in Project Overview.
+ *
+ * Recovery Options:
+ * A) Resume - Encourage accepting/completing a next step
+ * B) Clarify - Address open questions via Messages
+ * C) Reset - Clear accepted steps (local state only)
+ *
+ * Auto-dismisses when:
+ * - User takes a meaningful action (accepts/completes step)
+ * - User navigates to Messages to discuss
+ * - User manually dismisses
+ */
+
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowRight, MessageSquare, RefreshCw, X, HelpCircle } from 'lucide-react';
+import { Card, CardContent, Button } from '@/components/ui';
+import { cn } from '@/lib/utils';
+import { clearRecovery } from '@/utils/momentumRecovery';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface NextStep {
+  id: string;
+  text: string;
+  priority?: string;
+}
+
+interface OpenQuestion {
+  text: string;
+  conversationName?: string;
+}
+
+interface Snapshot {
+  openQuestions?: OpenQuestion[];
+  aiEnabled?: boolean;
+}
+
+type NextStepStatus = 'suggested' | 'accepted' | 'completed';
+
+interface MomentumRecoveryPanelProps {
+  projectId: string;
+  projectName?: string;
+  snapshot: Snapshot | null;
+  nextSteps: NextStep[];
+  nextStepStates: Record<string, NextStepStatus>;
+  onAcceptStep: (stepId: string) => void;
+  onClearAcceptedSteps?: () => void;
+  onDismiss: () => void;
+  className?: string;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function MomentumRecoveryPanel({
+  projectId,
+  projectName,
+  snapshot,
+  nextSteps,
+  nextStepStates,
+  onAcceptStep,
+  onClearAcceptedSteps,
+  onDismiss,
+  className,
+}: MomentumRecoveryPanelProps) {
+  const navigate = useNavigate();
+
+  // Get step status helper
+  const getStepStatus = (stepId: string): NextStepStatus => {
+    return nextStepStates[stepId] || 'suggested';
+  };
+
+  // Get actionable steps (accepted first, then suggested, max 3)
+  const actionableSteps = React.useMemo(() => {
+    const accepted = nextSteps.filter(s => getStepStatus(s.id) === 'accepted');
+    const suggested = nextSteps.filter(s => getStepStatus(s.id) === 'suggested');
+
+    // Prioritize by priority within each group
+    const sortByPriority = (a: NextStep, b: NextStep) => {
+      const order: Record<string, number> = { high: 0, medium: 1, low: 2 };
+      const aPriority = order[a.priority || ''] ?? 3;
+      const bPriority = order[b.priority || ''] ?? 3;
+      return aPriority - bPriority;
+    };
+
+    accepted.sort(sortByPriority);
+    suggested.sort(sortByPriority);
+
+    return [...accepted, ...suggested].slice(0, 3);
+  }, [nextSteps, nextStepStates]);
+
+  // Get open questions (max 2)
+  const openQuestions = React.useMemo(() => {
+    return (snapshot?.openQuestions || []).slice(0, 2);
+  }, [snapshot]);
+
+  // Count of accepted steps (for reset option)
+  const acceptedCount = React.useMemo(() => {
+    return Object.values(nextStepStates).filter(s => s === 'accepted').length;
+  }, [nextStepStates]);
+
+  // Handle step action
+  const handleStepAction = (step: NextStep) => {
+    const status = getStepStatus(step.id);
+    if (status === 'suggested') {
+      onAcceptStep(step.id);
+    }
+    // Auto-dismiss after action
+    handleDismiss();
+  };
+
+  // Handle discuss in messages
+  const handleDiscuss = () => {
+    const prefillText = encodeURIComponent(
+      "Quick clarity check — what's blocking progress here?"
+    );
+    navigate(`/messages?projectId=${projectId}&prefill=${prefillText}`);
+    handleDismiss();
+  };
+
+  // Handle reset accepted steps
+  const handleReset = () => {
+    if (onClearAcceptedSteps) {
+      onClearAcceptedSteps();
+    }
+    handleDismiss();
+  };
+
+  // Handle dismiss
+  const handleDismiss = () => {
+    clearRecovery(projectId);
+    onDismiss();
+  };
+
+  // Determine which options to show
+  const hasSteps = actionableSteps.length > 0;
+  const hasQuestions = openQuestions.length > 0;
+  const hasAcceptedSteps = acceptedCount > 0;
+
+  return (
+    <Card className={cn(
+      'border-indigo-100 bg-gradient-to-r from-indigo-50/50 to-purple-50/30',
+      className
+    )}>
+      <CardContent className="py-4">
+        {/* Header */}
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">
+              Let's restart momentum
+            </h3>
+            <p className="text-xs text-gray-500 mt-0.5">
+              {projectName
+                ? `${projectName} has been quiet — what's the best next move?`
+                : "This project's been quiet — what's the best next move?"
+              }
+            </p>
+          </div>
+          <button
+            onClick={handleDismiss}
+            className="p-1 text-gray-400 hover:text-gray-600 transition-colors rounded"
+            aria-label="Dismiss recovery panel"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Recovery Options */}
+        <div className="space-y-4">
+          {/* Option A: Resume - Show actionable steps */}
+          {hasSteps && (
+            <div className="space-y-2">
+              <h4 className="text-xs font-medium text-gray-600 uppercase tracking-wide">
+                Resume
+              </h4>
+              <div className="space-y-2">
+                {actionableSteps.map((step) => {
+                  const status = getStepStatus(step.id);
+                  const isAccepted = status === 'accepted';
+
+                  return (
+                    <div
+                      key={step.id}
+                      className={cn(
+                        'flex items-center gap-3 p-2 rounded-lg border transition-colors',
+                        isAccepted
+                          ? 'bg-blue-50/50 border-blue-200'
+                          : 'bg-white border-gray-200 hover:border-indigo-300'
+                      )}
+                    >
+                      <ArrowRight className={cn(
+                        'w-4 h-4 flex-shrink-0',
+                        step.priority === 'high' ? 'text-red-500' :
+                        step.priority === 'medium' ? 'text-amber-500' :
+                        'text-blue-500'
+                      )} />
+                      <span className="flex-1 text-sm text-gray-700 truncate">
+                        {step.text}
+                      </span>
+                      {!isAccepted && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleStepAction(step)}
+                          className="text-xs h-7 px-2 text-indigo-600 hover:text-indigo-700 hover:bg-indigo-50"
+                        >
+                          Accept
+                        </Button>
+                      )}
+                      {isAccepted && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 font-medium">
+                          accepted
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Option B: Clarify - Show open questions */}
+          {hasQuestions && (
+            <div className="space-y-2">
+              <h4 className="text-xs font-medium text-gray-600 uppercase tracking-wide">
+                Clarify
+              </h4>
+              <div className="space-y-2">
+                {openQuestions.map((q, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-center gap-3 p-2 rounded-lg border border-gray-200 bg-white"
+                  >
+                    <HelpCircle className="w-4 h-4 flex-shrink-0 text-amber-500" />
+                    <span className="flex-1 text-sm text-gray-600 truncate">
+                      {q.text}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleDiscuss}
+                className="w-full text-xs h-8 gap-2"
+              >
+                <MessageSquare className="w-3.5 h-3.5" />
+                Discuss in Messages
+              </Button>
+            </div>
+          )}
+
+          {/* Option C: Reset - Only if there are accepted steps */}
+          {hasAcceptedSteps && onClearAcceptedSteps && (
+            <div className="pt-2 border-t border-gray-100">
+              <button
+                onClick={handleReset}
+                className="flex items-center gap-2 text-xs text-gray-500 hover:text-gray-700 transition-colors"
+              >
+                <RefreshCw className="w-3.5 h-3.5" />
+                Clear {acceptedCount} accepted step{acceptedCount > 1 ? 's' : ''} and start fresh
+              </button>
+            </div>
+          )}
+
+          {/* Fallback when no options available */}
+          {!hasSteps && !hasQuestions && (
+            <div className="text-center py-2">
+              <p className="text-sm text-gray-500">
+                No pending items right now.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleDiscuss}
+                className="mt-2 text-xs h-8 gap-2"
+              >
+                <MessageSquare className="w-3.5 h-3.5" />
+                Start a conversation
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {/* Subtle dismiss option */}
+        <div className="mt-4 pt-3 border-t border-gray-100 text-center">
+          <button
+            onClick={handleDismiss}
+            className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            Not now
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default MomentumRecoveryPanel;

--- a/src/hooks/useMomentumStallNotification.ts
+++ b/src/hooks/useMomentumStallNotification.ts
@@ -1,0 +1,280 @@
+/**
+ * useMomentumStallNotification Hook
+ *
+ * Detects and triggers momentum stall notifications when a project
+ * appears to be stuck. Runs on page mount and visibility change.
+ *
+ * Usage:
+ * ```tsx
+ * useMomentumStallNotification(projectId, {
+ *   projectName: project?.name,
+ *   recentMessages,
+ *   projectAssets,
+ *   metmapSessions: songs,
+ *   snapshot,
+ *   nextStepStates,
+ * });
+ * ```
+ */
+
+import { useEffect, useRef, useCallback } from 'react';
+import { useNotifications } from '../contexts/NotificationContext';
+import {
+  MOMENTUM_STALL_NOTIFS_ENABLED,
+  getLastProjectActivityAt,
+  shouldTriggerMomentumStall,
+  buildStallNotificationContent,
+  setLastStallNotifiedAt,
+} from '../utils/momentumStall';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface RecentMessage {
+  id: string;
+  createdAt: string;
+  [key: string]: unknown;
+}
+
+interface ProjectAsset {
+  id: string;
+  createdAt: string;
+  updatedAt?: string;
+  [key: string]: unknown;
+}
+
+interface MetMapSession {
+  id: string;
+  createdAt: string;
+  updatedAt?: string;
+  [key: string]: unknown;
+}
+
+interface Snapshot {
+  openQuestions?: Array<{ text: string; [key: string]: unknown }>;
+  aiEnabled?: boolean;
+  [key: string]: unknown;
+}
+
+type NextStepStatus = 'suggested' | 'accepted' | 'completed';
+
+interface UseMomentumStallOptions {
+  /** Project name for notification display */
+  projectName?: string;
+  /** Recent messages with createdAt timestamps */
+  recentMessages?: RecentMessage[];
+  /** Project assets with createdAt/updatedAt timestamps */
+  projectAssets?: ProjectAsset[];
+  /** MetMap sessions with createdAt/updatedAt timestamps */
+  metmapSessions?: MetMapSession[];
+  /** AI snapshot with open questions */
+  snapshot?: Snapshot | null;
+  /** Next step states from localStorage */
+  nextStepStates?: Record<string, NextStepStatus>;
+  /** Whether data is still loading */
+  isLoading?: boolean;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Extract activity timestamps from available data
+ */
+function extractActivityTimestamps(options: UseMomentumStallOptions): ActivityTimestamps {
+  const { recentMessages, projectAssets, metmapSessions } = options;
+
+  // Get latest message timestamp
+  let latestMessage: string | null = null;
+  if (recentMessages && recentMessages.length > 0) {
+    // Messages are usually sorted newest first, but let's be safe
+    const sorted = [...recentMessages].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    );
+    latestMessage = sorted[0]?.createdAt || null;
+  }
+
+  // Get latest asset timestamp (use updatedAt if available, otherwise createdAt)
+  let latestAsset: string | null = null;
+  if (projectAssets && projectAssets.length > 0) {
+    const timestamps = projectAssets.map(a => a.updatedAt || a.createdAt);
+    const sorted = timestamps
+      .filter(Boolean)
+      .sort((a, b) => new Date(b).getTime() - new Date(a).getTime());
+    latestAsset = sorted[0] || null;
+  }
+
+  // Get latest MetMap session timestamp
+  let latestMetMap: string | null = null;
+  if (metmapSessions && metmapSessions.length > 0) {
+    const timestamps = metmapSessions.map(s => s.updatedAt || s.createdAt);
+    const sorted = timestamps
+      .filter(Boolean)
+      .sort((a, b) => new Date(b).getTime() - new Date(a).getTime());
+    latestMetMap = sorted[0] || null;
+  }
+
+  return {
+    latestMessage,
+    latestAsset,
+    latestMetMap,
+  };
+}
+
+/**
+ * Extract outstanding work signals from options
+ */
+function extractOutstandingSignals(options: UseMomentumStallOptions): OutstandingWork {
+  const { snapshot, nextStepStates } = options;
+
+  // Count accepted steps
+  const acceptedStepsCount = nextStepStates
+    ? Object.values(nextStepStates).filter(status => status === 'accepted').length
+    : 0;
+
+  // Count open questions (only if AI is enabled and snapshot exists)
+  const openQuestionsCount =
+    snapshot?.aiEnabled !== false && snapshot?.openQuestions
+      ? snapshot.openQuestions.length
+      : 0;
+
+  return {
+    acceptedStepsCount,
+    openQuestionsCount,
+  };
+}
+
+// ============================================================================
+// Hook Implementation
+// ============================================================================
+
+/**
+ * Hook to detect and trigger momentum stall notifications
+ *
+ * @param projectId - The project ID to check
+ * @param options - Data sources for stall detection
+ */
+export function useMomentumStallNotification(
+  projectId: string | undefined,
+  options: UseMomentumStallOptions = {}
+): void {
+  const { showNotification } = useNotifications();
+  const hasCheckedRef = useRef(false);
+  const lastCheckTimeRef = useRef<number>(0);
+
+  // Debounce check to avoid rapid re-checks
+  const DEBOUNCE_MS = 5000; // 5 seconds between checks
+
+  const checkAndNotify = useCallback(() => {
+    // Skip if feature is disabled
+    if (!MOMENTUM_STALL_NOTIFS_ENABLED) {
+      return;
+    }
+
+    // Skip if no project ID
+    if (!projectId) {
+      return;
+    }
+
+    // Skip if still loading
+    if (options.isLoading) {
+      return;
+    }
+
+    // Debounce
+    const now = Date.now();
+    if (now - lastCheckTimeRef.current < DEBOUNCE_MS) {
+      return;
+    }
+    lastCheckTimeRef.current = now;
+
+    // Extract timestamps and outstanding work
+    const timestamps = extractActivityTimestamps(options);
+    const lastActivityAt = getLastProjectActivityAt(timestamps);
+    const outstanding = extractOutstandingSignals(options);
+
+    // Check if we should trigger a notification
+    const result = shouldTriggerMomentumStall({
+      projectId,
+      lastActivityAt,
+      outstanding,
+    });
+
+    // If we should notify, show the notification
+    if (result.shouldNotify && result.hoursSinceActivity !== null) {
+      const content = buildStallNotificationContent({
+        projectId,
+        projectName: options.projectName || 'This project',
+        hoursSinceActivity: result.hoursSinceActivity,
+        outstanding,
+      });
+
+      // Show the notification
+      showNotification({
+        type: 'info',
+        title: content.title,
+        message: content.body,
+        data: {
+          projectId,
+          projectName: options.projectName,
+          acceptedStepsCount: content.acceptedStepsCount,
+          openQuestionsCount: content.openQuestionsCount,
+          action: 'momentum_stall',
+          // Primary CTA data
+          primaryAction: {
+            label: 'Open Project Overview',
+            url: `/projects/${projectId}/overview`,
+          },
+          // Secondary CTA if there are accepted steps
+          secondaryAction: content.acceptedStepsCount > 0 ? {
+            label: 'Review Next Steps',
+            url: `/projects/${projectId}/overview#next-steps`,
+          } : undefined,
+        },
+        projectId,
+        projectName: options.projectName,
+      });
+
+      // Record that we notified
+      setLastStallNotifiedAt(projectId, new Date().toISOString());
+    }
+  }, [projectId, options, showNotification]);
+
+  // Check on mount and when data changes
+  useEffect(() => {
+    // Skip initial check until data is loaded
+    if (options.isLoading) {
+      return;
+    }
+
+    // Perform check
+    checkAndNotify();
+
+    // Mark as checked
+    hasCheckedRef.current = true;
+  }, [checkAndNotify, options.isLoading]);
+
+  // Check on visibility change (when tab becomes visible)
+  useEffect(() => {
+    if (!projectId) {
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && hasCheckedRef.current) {
+        // Re-check when tab becomes visible (debounced)
+        checkAndNotify();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [projectId, checkAndNotify]);
+}
+
+export default useMomentumStallNotification;

--- a/src/hooks/useMomentumStallNotification.ts
+++ b/src/hooks/useMomentumStallNotification.ts
@@ -25,7 +25,10 @@ import {
   shouldTriggerMomentumStall,
   buildStallNotificationContent,
   setLastStallNotifiedAt,
+  ActivityTimestamps,
+  OutstandingWork,
 } from '../utils/momentumStall';
+import { activateRecovery } from '../utils/momentumRecovery';
 
 // ============================================================================
 // Types
@@ -239,6 +242,9 @@ export function useMomentumStallNotification(
 
       // Record that we notified
       setLastStallNotifiedAt(projectId, new Date().toISOString());
+
+      // Activate recovery state so the panel appears when user navigates
+      activateRecovery(projectId);
     }
   }, [projectId, options, showNotification]);
 

--- a/src/pages/ProjectOverview.tsx
+++ b/src/pages/ProjectOverview.tsx
@@ -45,6 +45,7 @@ import { cn } from '@/lib/utils';
 import { getApiUrl } from '@/utils/apiHelpers';
 import { isMetMapAsset } from '@/utils/assetHelpers';
 import { MetMapAssetCard } from '@/components/assets/MetMapAssetCard';
+import { useMomentumStallNotification } from '@/hooks/useMomentumStallNotification';
 
 // ============================================================================
 // Types
@@ -340,6 +341,18 @@ export default function ProjectOverview() {
     const encodedText = encodeURIComponent(discussText);
     navigate(`/messages?projectId=${projectId}&prefill=${encodedText}`);
   }, [projectId, navigate]);
+
+  // Momentum stall detection - triggers notification when project is stuck
+  const isDataLoading = projectLoading || messagesLoading || assetsLoading || aiSummaryState === 'loading';
+  useMomentumStallNotification(projectId, {
+    projectName: project?.name,
+    recentMessages,
+    projectAssets,
+    metmapSessions: songs,
+    snapshot,
+    nextStepStates,
+    isLoading: isDataLoading,
+  });
 
   // Load project details
   React.useEffect(() => {

--- a/src/utils/momentumRecovery.ts
+++ b/src/utils/momentumRecovery.ts
@@ -1,0 +1,113 @@
+/**
+ * Momentum Recovery State Utility
+ *
+ * Manages the short-lived recovery state that activates when a user
+ * clicks a momentum stall notification CTA. This state triggers the
+ * MomentumRecoveryPanel to appear in Project Overview.
+ *
+ * Recovery state expires after:
+ * - 24 hours automatically
+ * - First meaningful activity (message, step action, asset upload)
+ * - Manual dismissal
+ */
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** Hours until recovery state expires automatically */
+export const RECOVERY_EXPIRY_HOURS = 24;
+
+// ============================================================================
+// LocalStorage Helpers
+// ============================================================================
+
+/**
+ * Get the localStorage key for recovery state
+ */
+function getRecoveryKey(projectId: string): string {
+  return `fluxstudio_recovery_active_${projectId}`;
+}
+
+/**
+ * Check if recovery state is currently active for a project
+ * Returns true only if the state exists and hasn't expired
+ */
+export function isRecoveryActive(projectId: string): boolean {
+  try {
+    const stored = localStorage.getItem(getRecoveryKey(projectId));
+    if (!stored) {
+      return false;
+    }
+
+    // Check if expired
+    const activatedAt = new Date(stored);
+    if (isNaN(activatedAt.getTime())) {
+      // Invalid date, clear it
+      clearRecovery(projectId);
+      return false;
+    }
+
+    const now = new Date();
+    const hoursSinceActivation = (now.getTime() - activatedAt.getTime()) / (1000 * 60 * 60);
+
+    if (hoursSinceActivation > RECOVERY_EXPIRY_HOURS) {
+      // Expired, clear it
+      clearRecovery(projectId);
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Activate recovery state for a project
+ * Called when user clicks a momentum stall notification CTA
+ */
+export function activateRecovery(projectId: string): void {
+  try {
+    localStorage.setItem(getRecoveryKey(projectId), new Date().toISOString());
+  } catch {
+    // localStorage not available
+  }
+}
+
+/**
+ * Clear recovery state for a project
+ * Called when:
+ * - User dismisses the panel manually
+ * - User takes a meaningful action (message, step, asset)
+ * - Recovery expires
+ */
+export function clearRecovery(projectId: string): void {
+  try {
+    localStorage.removeItem(getRecoveryKey(projectId));
+  } catch {
+    // localStorage not available
+  }
+}
+
+/**
+ * Get the activation timestamp if recovery is active
+ * Returns null if not active
+ */
+export function getRecoveryActivatedAt(projectId: string): Date | null {
+  try {
+    const stored = localStorage.getItem(getRecoveryKey(projectId));
+    if (!stored) {
+      return null;
+    }
+
+    const activatedAt = new Date(stored);
+    if (isNaN(activatedAt.getTime())) {
+      return null;
+    }
+
+    return activatedAt;
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/momentumStall.ts
+++ b/src/utils/momentumStall.ts
@@ -1,0 +1,293 @@
+/**
+ * Momentum Stall Detection Utility
+ *
+ * Detects when a project appears to be stuck based on:
+ * - No meaningful activity for a configurable window (default 72 hours)
+ * - Outstanding work exists (accepted next steps or open questions)
+ *
+ * This is a client-side utility that uses existing data to create
+ * "helpful nudges" rather than constant pings.
+ */
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** Feature flag - set to false to disable momentum stall notifications */
+export const MOMENTUM_STALL_NOTIFS_ENABLED = true;
+
+/** Hours of inactivity before considering a project stalled (default: 72 = 3 days) */
+export const STALL_WINDOW_HOURS = 72;
+
+/** Hours between stall notifications for the same project (default: 24 = 1 day) */
+export const COOLDOWN_HOURS = 24;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ActivityTimestamps {
+  /** Latest message timestamp (ISO string or null) */
+  latestMessage?: string | null;
+  /** Latest asset upload/update timestamp (ISO string or null) */
+  latestAsset?: string | null;
+  /** Latest MetMap session update timestamp (ISO string or null) */
+  latestMetMap?: string | null;
+}
+
+export interface OutstandingWork {
+  /** Number of accepted (but not completed) next steps */
+  acceptedStepsCount: number;
+  /** Number of open questions from AI summaries */
+  openQuestionsCount: number;
+}
+
+export interface StallCheckResult {
+  /** Whether a momentum stall was detected */
+  isStalled: boolean;
+  /** Last activity timestamp (ISO string) */
+  lastActivityAt: string | null;
+  /** Hours since last activity */
+  hoursSinceActivity: number | null;
+  /** Outstanding work details */
+  outstanding: OutstandingWork;
+  /** Whether notification is on cooldown */
+  onCooldown: boolean;
+  /** Should we trigger a notification? */
+  shouldNotify: boolean;
+}
+
+// ============================================================================
+// LocalStorage Helpers
+// ============================================================================
+
+/**
+ * Get the localStorage key for last stall notification timestamp
+ */
+function getStallNotifiedKey(projectId: string): string {
+  return `fluxstudio_stall_notified_${projectId}`;
+}
+
+/**
+ * Get the last time a stall notification was shown for this project
+ */
+export function getLastStallNotifiedAt(projectId: string): string | null {
+  try {
+    return localStorage.getItem(getStallNotifiedKey(projectId));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Record that a stall notification was shown for this project
+ */
+export function setLastStallNotifiedAt(projectId: string, isoString: string): void {
+  try {
+    localStorage.setItem(getStallNotifiedKey(projectId), isoString);
+  } catch {
+    // localStorage not available
+  }
+}
+
+/**
+ * Clear the stall notification record (useful for testing or when activity resumes)
+ */
+export function clearLastStallNotifiedAt(projectId: string): void {
+  try {
+    localStorage.removeItem(getStallNotifiedKey(projectId));
+  } catch {
+    // localStorage not available
+  }
+}
+
+// ============================================================================
+// Activity Detection
+// ============================================================================
+
+/**
+ * Get the most recent activity timestamp from available data
+ */
+export function getLastProjectActivityAt(timestamps: ActivityTimestamps): string | null {
+  const validTimestamps: Date[] = [];
+
+  if (timestamps.latestMessage) {
+    const date = new Date(timestamps.latestMessage);
+    if (!isNaN(date.getTime())) {
+      validTimestamps.push(date);
+    }
+  }
+
+  if (timestamps.latestAsset) {
+    const date = new Date(timestamps.latestAsset);
+    if (!isNaN(date.getTime())) {
+      validTimestamps.push(date);
+    }
+  }
+
+  if (timestamps.latestMetMap) {
+    const date = new Date(timestamps.latestMetMap);
+    if (!isNaN(date.getTime())) {
+      validTimestamps.push(date);
+    }
+  }
+
+  if (validTimestamps.length === 0) {
+    return null;
+  }
+
+  // Return the most recent timestamp
+  const mostRecent = validTimestamps.reduce((latest, current) =>
+    current > latest ? current : latest
+  );
+
+  return mostRecent.toISOString();
+}
+
+// ============================================================================
+// Outstanding Work Detection
+// ============================================================================
+
+/**
+ * Get outstanding work signals from next step states and snapshot
+ */
+export function getOutstandingSignals(
+  nextStepStates: Record<string, 'suggested' | 'accepted' | 'completed'>,
+  openQuestionsCount: number
+): OutstandingWork {
+  // Count accepted (but not completed) steps
+  const acceptedStepsCount = Object.values(nextStepStates).filter(
+    status => status === 'accepted'
+  ).length;
+
+  return {
+    acceptedStepsCount,
+    openQuestionsCount,
+  };
+}
+
+// ============================================================================
+// Stall Detection
+// ============================================================================
+
+/**
+ * Check if a project should trigger a momentum stall notification
+ */
+export function shouldTriggerMomentumStall(params: {
+  projectId: string;
+  lastActivityAt: string | null;
+  outstanding: OutstandingWork;
+  now?: Date;
+  stallWindowHours?: number;
+  cooldownHours?: number;
+}): StallCheckResult {
+  const {
+    projectId,
+    lastActivityAt,
+    outstanding,
+    now = new Date(),
+    stallWindowHours = STALL_WINDOW_HOURS,
+    cooldownHours = COOLDOWN_HOURS,
+  } = params;
+
+  // If no activity data, we can't determine stall status
+  if (!lastActivityAt) {
+    return {
+      isStalled: false,
+      lastActivityAt: null,
+      hoursSinceActivity: null,
+      outstanding,
+      onCooldown: false,
+      shouldNotify: false,
+    };
+  }
+
+  // Calculate hours since last activity
+  const lastActivity = new Date(lastActivityAt);
+  const hoursSinceActivity = (now.getTime() - lastActivity.getTime()) / (1000 * 60 * 60);
+
+  // Check if beyond stall window
+  const isBeyondStallWindow = hoursSinceActivity > stallWindowHours;
+
+  // Check if there's outstanding work
+  const hasOutstandingWork =
+    outstanding.acceptedStepsCount > 0 || outstanding.openQuestionsCount > 0;
+
+  // Determine if project is stalled
+  const isStalled = isBeyondStallWindow && hasOutstandingWork;
+
+  // Check cooldown
+  const lastNotifiedAt = getLastStallNotifiedAt(projectId);
+  let onCooldown = false;
+
+  if (lastNotifiedAt) {
+    const lastNotified = new Date(lastNotifiedAt);
+    const hoursSinceNotified = (now.getTime() - lastNotified.getTime()) / (1000 * 60 * 60);
+    onCooldown = hoursSinceNotified < cooldownHours;
+  }
+
+  // Should notify only if stalled and not on cooldown
+  const shouldNotify = isStalled && !onCooldown;
+
+  return {
+    isStalled,
+    lastActivityAt,
+    hoursSinceActivity,
+    outstanding,
+    onCooldown,
+    shouldNotify,
+  };
+}
+
+// ============================================================================
+// Notification Message Builder
+// ============================================================================
+
+export interface StallNotificationContent {
+  title: string;
+  body: string;
+  projectId: string;
+  projectName: string;
+  acceptedStepsCount: number;
+  openQuestionsCount: number;
+}
+
+/**
+ * Build the notification content for a momentum stall
+ */
+export function buildStallNotificationContent(params: {
+  projectId: string;
+  projectName: string;
+  hoursSinceActivity: number;
+  outstanding: OutstandingWork;
+}): StallNotificationContent {
+  const { projectId, projectName, hoursSinceActivity, outstanding } = params;
+
+  // Build readable time period
+  const days = Math.floor(hoursSinceActivity / 24);
+  const timePeriod = days > 1 ? `${days} days` : days === 1 ? '1 day' : 'a while';
+
+  // Build body message
+  let body = `No activity in the last ${timePeriod}.`;
+
+  const parts: string[] = [];
+  if (outstanding.acceptedStepsCount > 0) {
+    parts.push(`${outstanding.acceptedStepsCount} accepted next step${outstanding.acceptedStepsCount > 1 ? 's' : ''}`);
+  }
+  if (outstanding.openQuestionsCount > 0) {
+    parts.push(`${outstanding.openQuestionsCount} open question${outstanding.openQuestionsCount > 1 ? 's' : ''}`);
+  }
+
+  if (parts.length > 0) {
+    body += ` ${parts.join(', ')}.`;
+  }
+
+  return {
+    title: 'Momentum stalled',
+    body,
+    projectId,
+    projectName,
+    acceptedStepsCount: outstanding.acceptedStepsCount,
+    openQuestionsCount: outstanding.openQuestionsCount,
+  };
+}


### PR DESCRIPTION
… are stuck

Adds client-side momentum stall detection to surface helpful nudges when a project appears stuck, reducing notification noise.

Detection Logic:
- Triggers when no activity for 72 hours (configurable STALL_WINDOW_HOURS)
- AND there are accepted next steps OR open questions
- Cooldown of 24 hours between notifications per project

Data Sources (all client-side, no backend changes):
- Latest message timestamp
- Latest asset upload/update timestamp
- Latest MetMap session timestamp
- Accepted next steps from localStorage
- Open questions from AI snapshot (0 if AI disabled)

Behavior:
- Runs on ProjectOverview mount after data loads
- Re-checks on tab visibility change (debounced)
- Records lastStallNotifiedAt in localStorage per project
- Shows toast notification with actionable CTAs

Noise Suppression:
- No notification if ANY recent activity within stall window
- No notification if no outstanding work (all steps completed, no questions)
- No notification during cooldown period
- Gracefully degrades when AI disabled (relies on accepted steps only)

Files:
- src/utils/momentumStall.ts (new) - Detection utility
- src/hooks/useMomentumStallNotification.ts (new) - Hook for pages
- src/pages/ProjectOverview.tsx (modified) - Wired hook