### PR TITLE
feat(projects): add team alignment signals in project overview

### DIFF
--- a/src/components/projects/TeamAlignmentPanel.tsx
+++ b/src/components/projects/TeamAlignmentPanel.tsx
@@ -1,0 +1,553 @@
+/**
+ * TeamAlignmentPanel Component
+ *
+ * A calm, compact panel showing team alignment signals in Project Overview.
+ * Helps teams coordinate on decisions, open questions, and next steps
+ * without heavy workflow overhead.
+ *
+ * Features:
+ * - Alignment Health indicator (Aligned / Needs attention / Unknown)
+ * - Decision acknowledgements (local storage)
+ * - Open question ownership (local storage)
+ * - Next responder suggestion
+ *
+ * All signals are client-side only (localStorage) and labeled as "Local signals".
+ */
+
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  CheckCircle2,
+  HelpCircle,
+  Users,
+  UserCheck,
+  MessageSquare,
+  ChevronDown,
+  ChevronUp,
+  Circle,
+} from 'lucide-react';
+import { Card, CardContent, Button } from '@/components/ui';
+import { cn } from '@/lib/utils';
+import { useAuth } from '@/contexts/AuthContext';
+import { useNotifications } from '@/contexts/NotificationContext';
+import {
+  makeDecisionId,
+  makeQuestionId,
+  getDecisionAcks,
+  setDecisionAck,
+  clearDecisionAck,
+  hasUserAcknowledged,
+  getQuestionOwner,
+  setQuestionOwner,
+  clearQuestionOwner,
+  computeAlignmentStatus,
+  getNextResponderSuggestion,
+  AlignmentStatus,
+} from '@/utils/teamAlignment';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface Decision {
+  text: string;
+  decidedBy?: string;
+  conversationName?: string;
+  conversationId?: string;
+}
+
+interface OpenQuestion {
+  text: string;
+  askedBy?: string;
+  conversationName?: string;
+  conversationId?: string;
+}
+
+interface NextStep {
+  id: string;
+  text: string;
+  priority?: string;
+}
+
+type NextStepStatus = 'suggested' | 'accepted' | 'completed';
+
+interface Snapshot {
+  decisions: Decision[];
+  openQuestions: OpenQuestion[];
+  nextSteps: NextStep[];
+  aiEnabled?: boolean;
+}
+
+interface TeamAlignmentPanelProps {
+  projectId: string;
+  projectName?: string;
+  snapshot: Snapshot | null;
+  nextStepStates: Record<string, NextStepStatus>;
+  participantCount?: number;
+  className?: string;
+}
+
+// ============================================================================
+// Sub-Components
+// ============================================================================
+
+/**
+ * Alignment health badge with calm, non-alarming styling
+ */
+const AlignmentHealthBadge: React.FC<{
+  status: AlignmentStatus;
+  reason: string;
+}> = ({ status, reason }) => {
+  const config = {
+    aligned: {
+      label: 'Aligned',
+      className: 'bg-green-50 text-green-700 border-green-200',
+      icon: CheckCircle2,
+    },
+    needs_attention: {
+      label: 'Needs attention',
+      className: 'bg-amber-50 text-amber-700 border-amber-200',
+      icon: Circle,
+    },
+    unknown: {
+      label: 'Unknown',
+      className: 'bg-gray-50 text-gray-500 border-gray-200',
+      icon: HelpCircle,
+    },
+  };
+
+  const { label, className, icon: Icon } = config[status];
+
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className={cn(
+          'inline-flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-full border',
+          className
+        )}
+        title={reason}
+      >
+        <Icon className="w-3 h-3" />
+        {label}
+      </span>
+      <span className="text-xs text-gray-400" title={reason}>
+        {reason}
+      </span>
+    </div>
+  );
+};
+
+/**
+ * Single decision row with acknowledge action
+ */
+const DecisionRow: React.FC<{
+  decision: Decision;
+  decisionId: string;
+  isAcknowledged: boolean;
+  ackCount: number;
+  onAcknowledge: () => void;
+  onUnacknowledge: () => void;
+}> = ({ decision, isAcknowledged, ackCount, onAcknowledge, onUnacknowledge }) => {
+  return (
+    <div className="flex items-start gap-2 py-2 border-b border-gray-100 last:border-0">
+      <CheckCircle2
+        className={cn(
+          'w-4 h-4 flex-shrink-0 mt-0.5',
+          isAcknowledged ? 'text-green-500' : 'text-gray-300'
+        )}
+      />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-gray-700 line-clamp-2">{decision.text}</p>
+        <div className="flex items-center gap-2 mt-1">
+          {decision.conversationName && (
+            <span className="text-xs text-gray-400">
+              from {decision.conversationName}
+            </span>
+          )}
+          <span className="text-xs text-gray-400">
+            {ackCount > 0 ? `${ackCount} ack'd` : 'No acks yet'}
+          </span>
+        </div>
+      </div>
+      <button
+        onClick={isAcknowledged ? onUnacknowledge : onAcknowledge}
+        className={cn(
+          'text-xs px-2 py-1 rounded transition-colors flex-shrink-0',
+          isAcknowledged
+            ? 'bg-green-100 text-green-700 hover:bg-green-200'
+            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+        )}
+      >
+        {isAcknowledged ? "Ack'd" : 'Ack'}
+      </button>
+    </div>
+  );
+};
+
+/**
+ * Single question row with assign action
+ */
+const QuestionRow: React.FC<{
+  question: OpenQuestion;
+  owner: { userName: string } | null;
+  onAssignToMe: () => void;
+  onUnassign: () => void;
+  onDiscuss: () => void;
+}> = ({ question, owner, onAssignToMe, onUnassign, onDiscuss }) => {
+  return (
+    <div className="flex items-start gap-2 py-2 border-b border-gray-100 last:border-0">
+      <HelpCircle className="w-4 h-4 flex-shrink-0 mt-0.5 text-amber-500" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-gray-700 line-clamp-2">{question.text}</p>
+        <div className="flex items-center gap-2 mt-1">
+          {question.conversationName && (
+            <span className="text-xs text-gray-400">
+              from {question.conversationName}
+            </span>
+          )}
+          {owner ? (
+            <span className="text-xs text-blue-600 flex items-center gap-1">
+              <UserCheck className="w-3 h-3" />
+              {owner.userName}
+            </span>
+          ) : (
+            <span className="text-xs text-gray-400">Unassigned</span>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center gap-1 flex-shrink-0">
+        {owner ? (
+          <button
+            onClick={onUnassign}
+            className="text-xs px-2 py-1 rounded bg-blue-100 text-blue-700 hover:bg-blue-200 transition-colors"
+          >
+            Unassign
+          </button>
+        ) : (
+          <button
+            onClick={onAssignToMe}
+            className="text-xs px-2 py-1 rounded bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors"
+          >
+            Assign to me
+          </button>
+        )}
+        <button
+          onClick={onDiscuss}
+          className="text-xs px-2 py-1 rounded border border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors"
+          title="Discuss in messages"
+        >
+          <MessageSquare className="w-3 h-3" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function TeamAlignmentPanel({
+  projectId,
+  snapshot,
+  nextStepStates,
+  participantCount,
+  className,
+}: TeamAlignmentPanelProps) {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const { addNotification } = useNotifications();
+
+  // Collapsed state
+  const [isExpanded, setIsExpanded] = React.useState(true);
+
+  // Force re-render trigger for localStorage updates
+  const [refreshKey, setRefreshKey] = React.useState(0);
+  const forceRefresh = () => setRefreshKey(k => k + 1);
+
+  // Extract data from snapshot
+  const decisions = snapshot?.decisions || [];
+  const openQuestions = snapshot?.openQuestions || [];
+  const displayedDecisions = decisions.slice(0, 3);
+  const displayedQuestions = openQuestions.slice(0, 3);
+
+  // Count accepted steps
+  const acceptedStepsCount = Object.values(nextStepStates).filter(
+    status => status === 'accepted'
+  ).length;
+
+  // Compute alignment status
+  const alignmentResult = React.useMemo(() => {
+    return computeAlignmentStatus({
+      decisions: displayedDecisions.map(d => ({
+        text: d.text,
+        conversationId: d.conversationId,
+      })),
+      openQuestions: displayedQuestions.map(q => ({
+        text: q.text,
+        conversationId: q.conversationId,
+      })),
+      acceptedStepsCount,
+      projectId,
+      currentUserId: user?.id,
+      participantCount,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    displayedDecisions,
+    displayedQuestions,
+    acceptedStepsCount,
+    projectId,
+    user?.id,
+    participantCount,
+    refreshKey,
+  ]);
+
+  // Get next responder suggestion
+  const suggestion = React.useMemo(() => {
+    return getNextResponderSuggestion({
+      decisions: displayedDecisions.map(d => ({
+        text: d.text,
+        conversationId: d.conversationId,
+      })),
+      openQuestions: displayedQuestions.map(q => ({
+        text: q.text,
+        conversationId: q.conversationId,
+      })),
+      acceptedStepsCount,
+      projectId,
+      currentUserId: user?.id,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    displayedDecisions,
+    displayedQuestions,
+    acceptedStepsCount,
+    projectId,
+    user?.id,
+    refreshKey,
+  ]);
+
+  // Decision handlers
+  const handleAcknowledge = React.useCallback(
+    (decision: Decision) => {
+      if (!user) return;
+      const decisionId = makeDecisionId(decision.text, decision.conversationId);
+      setDecisionAck(projectId, decisionId, user.id, user.name);
+      forceRefresh();
+      addNotification({
+        type: 'info',
+        title: 'Decision acknowledged',
+        message: 'Your acknowledgement has been recorded locally',
+        priority: 'low',
+      });
+    },
+    [projectId, user, addNotification]
+  );
+
+  const handleUnacknowledge = React.useCallback(
+    (decision: Decision) => {
+      if (!user) return;
+      const decisionId = makeDecisionId(decision.text, decision.conversationId);
+      clearDecisionAck(projectId, decisionId, user.id);
+      forceRefresh();
+    },
+    [projectId, user]
+  );
+
+  // Question handlers
+  const handleAssignToMe = React.useCallback(
+    (question: OpenQuestion) => {
+      if (!user) return;
+      const questionId = makeQuestionId(question.text, question.conversationId);
+      setQuestionOwner(projectId, questionId, user.id, user.name);
+      forceRefresh();
+      addNotification({
+        type: 'info',
+        title: 'Question assigned',
+        message: `You're now responsible for: "${question.text.slice(0, 50)}..."`,
+        priority: 'low',
+      });
+    },
+    [projectId, user, addNotification]
+  );
+
+  const handleUnassign = React.useCallback(
+    (question: OpenQuestion) => {
+      const questionId = makeQuestionId(question.text, question.conversationId);
+      clearQuestionOwner(projectId, questionId);
+      forceRefresh();
+    },
+    [projectId]
+  );
+
+  const handleDiscuss = React.useCallback(
+    (questionText: string) => {
+      const prefill = encodeURIComponent(`Let's discuss: "${questionText}"`);
+      navigate(`/messages?projectId=${projectId}&prefill=${prefill}`);
+    },
+    [navigate, projectId]
+  );
+
+  // Navigate to messages with suggestion prefill
+  const handleSuggestionAction = React.useCallback(() => {
+    if (suggestion.prefillText) {
+      const prefill = encodeURIComponent(suggestion.prefillText);
+      navigate(`/messages?projectId=${projectId}&prefill=${prefill}`);
+    } else {
+      navigate(`/messages?projectId=${projectId}`);
+    }
+  }, [navigate, projectId, suggestion.prefillText]);
+
+  // Get ack info for a decision
+  const getDecisionAckInfo = React.useCallback(
+    (decision: Decision) => {
+      const decisionId = makeDecisionId(decision.text, decision.conversationId);
+      const acks = getDecisionAcks(projectId);
+      const decisionAcks = acks[decisionId] || [];
+      const isAcknowledged = user
+        ? hasUserAcknowledged(projectId, decisionId, user.id)
+        : false;
+      return { isAcknowledged, ackCount: decisionAcks.length };
+    },
+    [projectId, user]
+  );
+
+  // Get owner info for a question
+  const getQuestionOwnerInfo = React.useCallback(
+    (question: OpenQuestion) => {
+      const questionId = makeQuestionId(question.text, question.conversationId);
+      return getQuestionOwner(projectId, questionId);
+    },
+    [projectId]
+  );
+
+  // Don't render if no meaningful data
+  if (
+    displayedDecisions.length === 0 &&
+    displayedQuestions.length === 0 &&
+    acceptedStepsCount === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <Card className={cn('border-gray-200', className)}>
+      <CardContent className="p-4">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <Users className="w-4 h-4 text-gray-400" />
+            <h4 className="text-sm font-medium text-gray-700">Team Alignment</h4>
+            <span className="text-xs text-gray-400">(Local signals)</span>
+          </div>
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="p-1 hover:bg-gray-100 rounded transition-colors"
+            aria-label={isExpanded ? 'Collapse' : 'Expand'}
+          >
+            {isExpanded ? (
+              <ChevronUp className="w-4 h-4 text-gray-400" />
+            ) : (
+              <ChevronDown className="w-4 h-4 text-gray-400" />
+            )}
+          </button>
+        </div>
+
+        {/* Alignment Health */}
+        <AlignmentHealthBadge
+          status={alignmentResult.status}
+          reason={alignmentResult.reason}
+        />
+
+        {isExpanded && (
+          <div className="mt-4 space-y-4">
+            {/* Decisions Section */}
+            {displayedDecisions.length > 0 && (
+              <div>
+                <h5 className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-2">
+                  Decisions ({displayedDecisions.length})
+                </h5>
+                <div className="bg-gray-50 rounded-lg p-2">
+                  {displayedDecisions.map((decision, idx) => {
+                    const decisionId = makeDecisionId(
+                      decision.text,
+                      decision.conversationId
+                    );
+                    const { isAcknowledged, ackCount } = getDecisionAckInfo(decision);
+                    return (
+                      <DecisionRow
+                        key={decisionId || idx}
+                        decision={decision}
+                        decisionId={decisionId}
+                        isAcknowledged={isAcknowledged}
+                        ackCount={ackCount}
+                        onAcknowledge={() => handleAcknowledge(decision)}
+                        onUnacknowledge={() => handleUnacknowledge(decision)}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Open Questions Section */}
+            {displayedQuestions.length > 0 && (
+              <div>
+                <h5 className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-2">
+                  Open Questions ({displayedQuestions.length})
+                </h5>
+                <div className="bg-gray-50 rounded-lg p-2">
+                  {displayedQuestions.map((question, idx) => {
+                    const questionId = makeQuestionId(
+                      question.text,
+                      question.conversationId
+                    );
+                    const owner = getQuestionOwnerInfo(question);
+                    return (
+                      <QuestionRow
+                        key={questionId || idx}
+                        question={question}
+                        owner={owner}
+                        onAssignToMe={() => handleAssignToMe(question)}
+                        onUnassign={() => handleUnassign(question)}
+                        onDiscuss={() => handleDiscuss(question.text)}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Next Responder Suggestion */}
+            {suggestion.action && (
+              <div className="pt-3 border-t border-gray-100">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm text-gray-600">{suggestion.suggestion}</p>
+                  {suggestion.action === 'discuss' ||
+                  suggestion.action === 'acknowledge_decision' ||
+                  suggestion.action === 'assign_question' ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleSuggestionAction}
+                      className="text-xs"
+                    >
+                      <MessageSquare className="w-3 h-3 mr-1" />
+                      Open Messages
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+            )}
+
+            {/* Footer */}
+            <p className="text-xs text-gray-400 pt-2 border-t border-gray-100">
+              Signals are lightweight and project-scoped
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/ProjectOverview.tsx
+++ b/src/pages/ProjectOverview.tsx
@@ -48,6 +48,7 @@ import { MetMapAssetCard } from '@/components/assets/MetMapAssetCard';
 import { useMomentumStallNotification } from '@/hooks/useMomentumStallNotification';
 import { isRecoveryActive, clearRecovery } from '@/utils/momentumRecovery';
 import { MomentumRecoveryPanel } from '@/components/projects/MomentumRecoveryPanel';
+import { TeamAlignmentPanel } from '@/components/projects/TeamAlignmentPanel';
 
 // ============================================================================
 // Types
@@ -921,6 +922,18 @@ export default function ProjectOverview() {
                             ))}
                           </div>
                         </div>
+                      )}
+
+                      {/* Team Alignment Signals */}
+                      {projectId && (snapshot.decisions.length > 0 || snapshot.openQuestions.length > 0) && (
+                        <TeamAlignmentPanel
+                          projectId={projectId}
+                          projectName={project?.name}
+                          snapshot={snapshot}
+                          nextStepStates={nextStepStates}
+                          participantCount={project?.members?.length}
+                          className="mb-4"
+                        />
                       )}
 
                       {/* Key decisions */}

--- a/src/utils/teamAlignment.ts
+++ b/src/utils/teamAlignment.ts
@@ -1,0 +1,449 @@
+/**
+ * Team Alignment Utilities
+ *
+ * Client-side utilities for tracking team alignment signals:
+ * - Decision acknowledgements
+ * - Open question ownership
+ * - Alignment status computation
+ *
+ * All data is stored in localStorage and labeled as "Local signals"
+ * since we don't have reliable backend persistence for these yet.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface DecisionAck {
+  userId: string;
+  userName: string;
+  acknowledgedAt: string;
+}
+
+export interface DecisionAcks {
+  [decisionId: string]: DecisionAck[];
+}
+
+export interface QuestionOwner {
+  userId: string;
+  userName: string;
+  assignedAt: string;
+}
+
+export interface QuestionOwners {
+  [questionId: string]: QuestionOwner;
+}
+
+export type AlignmentStatus = 'aligned' | 'needs_attention' | 'unknown';
+
+export interface AlignmentResult {
+  status: AlignmentStatus;
+  score: number;
+  reason: string;
+  breakdown: {
+    decisionScore: number;
+    questionScore: number;
+    momentumScore: number;
+  };
+}
+
+export interface AlignmentInput {
+  decisions: Array<{ text: string; conversationId?: string }>;
+  openQuestions: Array<{ text: string; conversationId?: string }>;
+  acceptedStepsCount: number;
+  projectId: string;
+  currentUserId?: string;
+  participantCount?: number;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DECISION_ACK_KEY_PREFIX = 'fluxstudio_decision_ack_';
+const QUESTION_OWNER_KEY_PREFIX = 'fluxstudio_question_owner_';
+
+// Scoring weights (total = 100)
+const DECISION_WEIGHT = 40;
+const QUESTION_WEIGHT = 40;
+const MOMENTUM_WEIGHT = 20;
+
+// Alignment thresholds
+const ALIGNED_THRESHOLD = 70;
+
+// ============================================================================
+// Stable ID Generation
+// ============================================================================
+
+/**
+ * Generate a stable ID from text content, optionally salted with additional context.
+ * Uses a simple hash algorithm for deterministic IDs across sessions.
+ */
+export function makeStableId(text: string, salt?: string): string {
+  const input = salt ? `${text}::${salt}` : text;
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    const char = input.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return `id_${Math.abs(hash).toString(36)}`;
+}
+
+/**
+ * Generate a stable decision ID from decision text and optional conversation context.
+ */
+export function makeDecisionId(text: string, conversationId?: string): string {
+  return makeStableId(text, conversationId || 'global');
+}
+
+/**
+ * Generate a stable question ID from question text and optional conversation context.
+ */
+export function makeQuestionId(text: string, conversationId?: string): string {
+  return makeStableId(text, conversationId || 'global');
+}
+
+// ============================================================================
+// LocalStorage Helpers
+// ============================================================================
+
+function getDecisionAckKey(projectId: string): string {
+  return `${DECISION_ACK_KEY_PREFIX}${projectId}`;
+}
+
+function getQuestionOwnerKey(projectId: string): string {
+  return `${QUESTION_OWNER_KEY_PREFIX}${projectId}`;
+}
+
+// ============================================================================
+// Decision Acknowledgement
+// ============================================================================
+
+/**
+ * Get all decision acknowledgements for a project.
+ */
+export function getDecisionAcks(projectId: string): DecisionAcks {
+  try {
+    const stored = localStorage.getItem(getDecisionAckKey(projectId));
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch {
+    // localStorage not available or invalid JSON
+  }
+  return {};
+}
+
+/**
+ * Check if a specific user has acknowledged a decision.
+ */
+export function hasUserAcknowledged(
+  projectId: string,
+  decisionId: string,
+  userId: string
+): boolean {
+  const acks = getDecisionAcks(projectId);
+  const decisionAcks = acks[decisionId] || [];
+  return decisionAcks.some(ack => ack.userId === userId);
+}
+
+/**
+ * Get acknowledgement count for a decision.
+ */
+export function getAckCount(projectId: string, decisionId: string): number {
+  const acks = getDecisionAcks(projectId);
+  return (acks[decisionId] || []).length;
+}
+
+/**
+ * Acknowledge a decision for a user.
+ */
+export function setDecisionAck(
+  projectId: string,
+  decisionId: string,
+  userId: string,
+  userName: string
+): void {
+  try {
+    const acks = getDecisionAcks(projectId);
+    const decisionAcks = acks[decisionId] || [];
+
+    // Don't add duplicate
+    if (decisionAcks.some(ack => ack.userId === userId)) {
+      return;
+    }
+
+    decisionAcks.push({
+      userId,
+      userName,
+      acknowledgedAt: new Date().toISOString(),
+    });
+
+    acks[decisionId] = decisionAcks;
+    localStorage.setItem(getDecisionAckKey(projectId), JSON.stringify(acks));
+  } catch {
+    // localStorage not available
+  }
+}
+
+/**
+ * Remove acknowledgement for a user (reversible action).
+ */
+export function clearDecisionAck(
+  projectId: string,
+  decisionId: string,
+  userId: string
+): void {
+  try {
+    const acks = getDecisionAcks(projectId);
+    const decisionAcks = acks[decisionId] || [];
+
+    acks[decisionId] = decisionAcks.filter(ack => ack.userId !== userId);
+
+    // Clean up empty arrays
+    if (acks[decisionId].length === 0) {
+      delete acks[decisionId];
+    }
+
+    localStorage.setItem(getDecisionAckKey(projectId), JSON.stringify(acks));
+  } catch {
+    // localStorage not available
+  }
+}
+
+// ============================================================================
+// Open Question Ownership
+// ============================================================================
+
+/**
+ * Get all question owners for a project.
+ */
+export function getQuestionOwners(projectId: string): QuestionOwners {
+  try {
+    const stored = localStorage.getItem(getQuestionOwnerKey(projectId));
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch {
+    // localStorage not available or invalid JSON
+  }
+  return {};
+}
+
+/**
+ * Get the owner of a specific question.
+ */
+export function getQuestionOwner(
+  projectId: string,
+  questionId: string
+): QuestionOwner | null {
+  const owners = getQuestionOwners(projectId);
+  return owners[questionId] || null;
+}
+
+/**
+ * Assign a question to a user.
+ */
+export function setQuestionOwner(
+  projectId: string,
+  questionId: string,
+  userId: string,
+  userName: string
+): void {
+  try {
+    const owners = getQuestionOwners(projectId);
+    owners[questionId] = {
+      userId,
+      userName,
+      assignedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(getQuestionOwnerKey(projectId), JSON.stringify(owners));
+  } catch {
+    // localStorage not available
+  }
+}
+
+/**
+ * Clear question ownership (unassign).
+ */
+export function clearQuestionOwner(projectId: string, questionId: string): void {
+  try {
+    const owners = getQuestionOwners(projectId);
+    delete owners[questionId];
+    localStorage.setItem(getQuestionOwnerKey(projectId), JSON.stringify(owners));
+  } catch {
+    // localStorage not available
+  }
+}
+
+// ============================================================================
+// Alignment Status Computation
+// ============================================================================
+
+/**
+ * Compute alignment status based on decision acks, question ownership, and momentum.
+ *
+ * Scoring breakdown:
+ * - Decision acknowledgement coverage (0-40): acknowledgedDecisions / totalDecisions * 40
+ * - Open question ownership (0-40): assignedQuestions / totalQuestions * 40
+ * - Momentum readiness (0-20): +20 if acceptedStepsCount > 0
+ *
+ * Status thresholds:
+ * - Aligned: score >= 70
+ * - Needs attention: score 1-69
+ * - Unknown: missing key inputs or no data
+ */
+export function computeAlignmentStatus(input: AlignmentInput): AlignmentResult {
+  const { decisions, openQuestions, acceptedStepsCount, projectId, currentUserId } = input;
+
+  // If no decisions and no questions, status is unknown
+  if (decisions.length === 0 && openQuestions.length === 0) {
+    return {
+      status: 'unknown',
+      score: 0,
+      reason: 'No decisions or questions to track',
+      breakdown: { decisionScore: 0, questionScore: 0, momentumScore: 0 },
+    };
+  }
+
+  const acks = getDecisionAcks(projectId);
+  const owners = getQuestionOwners(projectId);
+
+  // Calculate decision acknowledgement score
+  let decisionScore = 0;
+  if (decisions.length > 0) {
+    const displayedDecisions = decisions.slice(0, 3); // We only show max 3
+    let acknowledgedCount = 0;
+    for (const decision of displayedDecisions) {
+      const decisionId = makeDecisionId(decision.text, decision.conversationId);
+      const decisionAcks = acks[decisionId] || [];
+      // Count as acknowledged if current user has ack'd (since we can't reliably track others)
+      if (currentUserId && decisionAcks.some(a => a.userId === currentUserId)) {
+        acknowledgedCount++;
+      } else if (decisionAcks.length > 0) {
+        // At least someone acknowledged
+        acknowledgedCount++;
+      }
+    }
+    decisionScore = Math.round((acknowledgedCount / displayedDecisions.length) * DECISION_WEIGHT);
+  } else {
+    // No decisions means full score for this category
+    decisionScore = DECISION_WEIGHT;
+  }
+
+  // Calculate question ownership score
+  let questionScore = 0;
+  if (openQuestions.length > 0) {
+    const displayedQuestions = openQuestions.slice(0, 3); // We only show max 3
+    let assignedCount = 0;
+    for (const question of displayedQuestions) {
+      const questionId = makeQuestionId(question.text, question.conversationId);
+      if (owners[questionId]) {
+        assignedCount++;
+      }
+    }
+    questionScore = Math.round((assignedCount / displayedQuestions.length) * QUESTION_WEIGHT);
+  } else {
+    // No questions means full score for this category
+    questionScore = QUESTION_WEIGHT;
+  }
+
+  // Calculate momentum score
+  const momentumScore = acceptedStepsCount > 0 ? MOMENTUM_WEIGHT : 0;
+
+  // Total score
+  const score = decisionScore + questionScore + momentumScore;
+
+  // Determine status
+  let status: AlignmentStatus;
+  let reason: string;
+
+  if (score >= ALIGNED_THRESHOLD) {
+    status = 'aligned';
+    reason = 'Team is tracking decisions and questions';
+  } else if (score > 0) {
+    status = 'needs_attention';
+    // Build specific reason
+    const reasons: string[] = [];
+    if (decisionScore < DECISION_WEIGHT && decisions.length > 0) {
+      reasons.push('decisions need acknowledgement');
+    }
+    if (questionScore < QUESTION_WEIGHT && openQuestions.length > 0) {
+      reasons.push('questions need owners');
+    }
+    if (momentumScore === 0 && acceptedStepsCount === 0) {
+      reasons.push('no next steps accepted');
+    }
+    reason = reasons.length > 0 ? `Some ${reasons.join(', ')}` : 'Partial alignment';
+  } else {
+    status = 'unknown';
+    reason = 'Not enough data to determine alignment';
+  }
+
+  return {
+    status,
+    score,
+    reason,
+    breakdown: {
+      decisionScore,
+      questionScore,
+      momentumScore,
+    },
+  };
+}
+
+/**
+ * Get a suggestion for the next action to improve alignment.
+ */
+export function getNextResponderSuggestion(input: AlignmentInput): {
+  suggestion: string;
+  action: 'assign_question' | 'accept_step' | 'acknowledge_decision' | 'discuss' | null;
+  prefillText?: string;
+} {
+  const { decisions, openQuestions, acceptedStepsCount, projectId } = input;
+
+  const owners = getQuestionOwners(projectId);
+  const acks = getDecisionAcks(projectId);
+
+  // Priority 1: Unassigned open questions
+  const displayedQuestions = openQuestions.slice(0, 3);
+  for (const question of displayedQuestions) {
+    const questionId = makeQuestionId(question.text, question.conversationId);
+    if (!owners[questionId]) {
+      return {
+        suggestion: 'Pick an owner for an open question',
+        action: 'assign_question',
+        prefillText: `Let's discuss: "${question.text}"`,
+      };
+    }
+  }
+
+  // Priority 2: No accepted next steps
+  if (acceptedStepsCount === 0) {
+    return {
+      suggestion: 'Choose a next step to move forward',
+      action: 'accept_step',
+    };
+  }
+
+  // Priority 3: Unacknowledged decisions
+  const displayedDecisions = decisions.slice(0, 3);
+  for (const decision of displayedDecisions) {
+    const decisionId = makeDecisionId(decision.text, decision.conversationId);
+    const decisionAcks = acks[decisionId] || [];
+    if (decisionAcks.length === 0) {
+      return {
+        suggestion: 'Share or confirm a decision with the team',
+        action: 'acknowledge_decision',
+        prefillText: `Confirming decision: "${decision.text}"`,
+      };
+    }
+  }
+
+  // Everything looks good
+  return {
+    suggestion: 'Team alignment looks good',
+    action: null,
+  };
+}


### PR DESCRIPTION
- Create teamAlignment.ts utility for localStorage-based alignment tracking
- Create TeamAlignmentPanel component with:
  - Alignment Health indicator (Aligned/Needs attention/Unknown)
  - Decision acknowledgements (max 3, with ack/unack)
  - Open question ownership (assign to me/unassign + discuss)
  - Next responder suggestion with CTA
- Wire panel into ProjectOverview above Key Decisions section
- All signals are client-side only (localStorage) with "Local signals" label

Scoring: Decision acks (40) + Question ownership (40) + Momentum (20) = 100 Thresholds: >=70 Aligned, 1-69 Needs attention, 0 Unknown Graceful degradation when AI disabled or no participants available