### PR TITLE
Full UI/UX polish pass: loading skeletons, accessibility, dark mode

### DIFF
--- a/src/components/DashboardShell.tsx
+++ b/src/components/DashboardShell.tsx
@@ -1,22 +1,14 @@
-import { forwardRef, useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { forwardRef, lazy, Suspense, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
-import { useOrganization } from '../contexts/OrganizationContext';
 import { useCommandPalette } from '../hooks/useCommandPalette';
-import { useBreakpoint } from '../hooks/useBreakpoint';
-import { useMessaging } from '../hooks/useMessaging';
-import { useFiles } from '../hooks/useFiles';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
-import { CommandPalette } from './search/CommandPalette';
-import { EnhancedHeader } from './EnhancedHeader';
-import { File } from '../pages/File';
-import { MessagingSidepanel } from './messaging/MessagingSidepanel';
 import { FloatingMessageButton } from './messaging/FloatingMessageButton';
-import {
-  Building2,
-  Users,
-  FolderOpen,
-} from 'lucide-react';
+
+// Lazy-load heavy components to keep dashboard chunk under 500 KB
+const EnhancedHeader = lazy(() => import('./EnhancedHeader').then(m => ({ default: m.EnhancedHeader })));
+const CommandPalette = lazy(() => import('./search/CommandPalette').then(m => ({ default: m.CommandPalette })));
+const File = lazy(() => import('../pages/File').then(m => ({ default: m.File })));
+const MessagingSidepanel = lazy(() => import('./messaging/MessagingSidepanel').then(m => ({ default: m.MessagingSidepanel })));
 
 // ForwardRef wrapper for button elements to fix Slot ref warnings
 const ForwardedButton = forwardRef<HTMLButtonElement, React.ComponentProps<'button'>>((props, ref) => (
@@ -35,26 +27,10 @@ interface DashboardShellProps {
 }
 
 export function DashboardShell({ children: _children }: DashboardShellProps) {
-  // Navigation and auth hooks - some reserved for future use
-  useNavigate(); // Reserved for navigation
-  useLocation(); // Reserved for location-based navigation
   const { user } = useAuth();
-  useOrganization(); // Reserved for organization context features
   const { isOpen: isCommandPaletteOpen, open: openCommandPalette, close: closeCommandPalette } = useCommandPalette();
-  useBreakpoint(); // Reserved for responsive behavior
-  useMessaging(); // Reserved for unread count display
-  useFiles(); // Reserved for file count display
-  const [, setIsLoading] = useState(true);
-  const [activeView, setActiveView] = useState('organizations');
+  const [activeView, setActiveView] = useState('projects');
   const [isMessagingOpen, setIsMessagingOpen] = useState(false);
-
-  useEffect(() => {
-    // Simulate initial data loading
-    const timer = setTimeout(() => {
-      setIsLoading(false);
-    }, 500);
-    return () => clearTimeout(timer);
-  }, []);
 
   const handleViewChange = (view: string) => {
     if (view === 'messages') {
@@ -111,50 +87,31 @@ export function DashboardShell({ children: _children }: DashboardShellProps) {
 
   if (!user) return null;
 
-  // Navigation items based on user role and context
-  // Note: getNavigationItems and getContextualItems are available for sidebar navigation
-  // They use: organizations, teams, projects, files, unreadCount, location, user, currentOrganization, currentTeam, currentProject
-
   return (
     <div className="min-h-screen w-full bg-background">
       {/* Header */}
-      <EnhancedHeader
-        openCommandPalette={openCommandPalette}
-        activeView={activeView}
-        onViewChange={handleViewChange}
-        onMessagingToggle={() => setIsMessagingOpen(true)}
-      />
+      <Suspense fallback={<div className="sticky top-0 z-50 w-full h-16 bg-neutral-900 border-b border-neutral-700/50" />}>
+        <EnhancedHeader
+          openCommandPalette={openCommandPalette}
+          activeView={activeView}
+          onViewChange={handleViewChange}
+          onMessagingToggle={() => setIsMessagingOpen(true)}
+        />
+      </Suspense>
 
       {/* Main Content */}
-      <main className="flex-1 overflow-y-auto bg-gradient-to-br from-gray-50 to-gray-100">
+      <main className="flex-1 overflow-y-auto bg-gradient-to-br from-neutral-50 to-neutral-100 dark:from-neutral-900 dark:to-neutral-950">
         <div className="max-w-7xl mx-auto p-4 md:p-6 lg:p-8 animate-fadeIn">
-
-          {/* Page Content - View-specific content based on activeView */}
-          <div className="bg-white rounded-2xl border border-gray-200 p-6 shadow-xl animate-slideUp">
-            {activeView === 'organizations' && (
-              <div className="text-center py-12">
-                <Building2 className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                <h2 className="text-xl font-semibold text-gray-900 mb-2">Organizations</h2>
-                <p className="text-gray-600">Manage your organizations and settings</p>
-              </div>
-            )}
-            {activeView === 'teams' && (
-              <div className="text-center py-12">
-                <Users className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                <h2 className="text-xl font-semibold text-gray-900 mb-2">Teams</h2>
-                <p className="text-gray-600">Collaborate with your team members</p>
-              </div>
-            )}
-            {activeView === 'projects' && (
-              <div className="text-center py-12">
-                <FolderOpen className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                <h2 className="text-xl font-semibold text-gray-900 mb-2">Projects</h2>
-                <p className="text-gray-600">Manage your creative projects</p>
-              </div>
-            )}
-            {activeView === 'files' && (
+          <div className="bg-white dark:bg-neutral-900 rounded-2xl border border-neutral-200 dark:border-neutral-700 p-6 shadow-xl animate-slideUp">
+            {activeView === 'files' ? (
               <div className="w-full">
-                <File />
+                <Suspense fallback={<div className="animate-pulse h-64 bg-neutral-100 dark:bg-neutral-800 rounded" />}>
+                  <File />
+                </Suspense>
+              </div>
+            ) : (
+              <div className="text-center py-12 text-neutral-500 dark:text-neutral-400">
+                <p>Select a view from the navigation above.</p>
               </div>
             )}
           </div>
@@ -162,13 +119,17 @@ export function DashboardShell({ children: _children }: DashboardShellProps) {
       </main>
 
       {/* Global Command Palette */}
-      <CommandPalette />
+      <Suspense fallback={null}>
+        <CommandPalette />
+      </Suspense>
 
       {/* Messaging Sidepanel - Available from any view */}
-      <MessagingSidepanel
-        isOpen={isMessagingOpen}
-        onClose={() => setIsMessagingOpen(false)}
-      />
+      <Suspense fallback={null}>
+        <MessagingSidepanel
+          isOpen={isMessagingOpen}
+          onClose={() => setIsMessagingOpen(false)}
+        />
+      </Suspense>
 
       {/* Floating Message Button - Always visible for quick access */}
       <FloatingMessageButton

--- a/src/components/loading/LoadingStates.tsx
+++ b/src/components/loading/LoadingStates.tsx
@@ -9,7 +9,7 @@ import { cn } from '../../lib/utils';
 
 export function DashboardSkeleton() {
   return (
-    <div className="flex-1 space-y-6 p-6">
+    <div className="flex-1 space-y-6 p-6" role="status" aria-busy="true" aria-label="Loading dashboard">
       {/* Header Skeleton */}
       <div className="flex items-center justify-between">
         <div className="space-y-2">
@@ -29,7 +29,7 @@ export function DashboardSkeleton() {
       {/* Contextual Cards Skeleton */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {[1, 2, 3].map((i) => (
-          <Card key={i} className="border-l-4 border-l-gray-200">
+          <Card key={i} className="border-l-4 border-l-neutral-200 dark:border-l-neutral-700">
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
@@ -61,7 +61,7 @@ export function DashboardSkeleton() {
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-6">
               <div className="lg:col-span-2 space-y-4">
                 {[1, 2, 3, 4, 5].map((i) => (
-                  <div key={i} className="flex items-start gap-3 pb-3 border-b border-gray-100">
+                  <div key={i} className="flex items-start gap-3 pb-3 border-b border-neutral-100 dark:border-neutral-800">
                     <Skeleton animation="shimmer" className="w-8 h-8 rounded-lg flex-shrink-0" />
                     <div className="flex-1 space-y-2">
                       <div className="flex items-center justify-between">
@@ -105,7 +105,7 @@ export function DashboardSkeleton() {
 
 export function WorkflowSkeleton() {
   return (
-    <div className="space-y-6">
+    <div className="space-y-6" role="status" aria-busy="true" aria-label="Loading workflows">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="space-y-2">
@@ -137,9 +137,9 @@ export function WorkflowSkeleton() {
 
 export function MessagingSkeleton() {
   return (
-    <div className="flex h-[600px] border rounded-lg overflow-hidden">
+    <div className="flex h-[600px] border rounded-lg overflow-hidden" role="status" aria-busy="true" aria-label="Loading messages">
       {/* Sidebar */}
-      <div className="w-80 border-r bg-gray-50 p-4 space-y-4">
+      <div className="w-80 border-r bg-neutral-50 dark:bg-neutral-800 p-4 space-y-4">
         <div className="flex items-center justify-between">
           <Skeleton animation="shimmer" className="h-6 w-24" />
           <Skeleton animation="shimmer" variant="circular" size="sm" />
@@ -164,7 +164,7 @@ export function MessagingSkeleton() {
       {/* Main Chat Area */}
       <div className="flex-1 flex flex-col">
         {/* Header */}
-        <div className="p-4 border-b bg-white">
+        <div className="p-4 border-b bg-white dark:bg-neutral-900">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <Skeleton animation="shimmer" variant="avatar" size="sm" />
@@ -205,7 +205,7 @@ export function MessagingSkeleton() {
         </div>
 
         {/* Input */}
-        <div className="p-4 border-t bg-white">
+        <div className="p-4 border-t bg-white dark:bg-neutral-900">
           <div className="flex items-center gap-2">
             <Skeleton animation="shimmer" className="h-8 w-8 rounded" />
             <Skeleton animation="shimmer" className="h-10 flex-1" />
@@ -219,7 +219,7 @@ export function MessagingSkeleton() {
 
 export function NotificationSkeleton() {
   return (
-    <Card className="w-full max-w-96 max-h-[600px]">
+    <Card className="w-full max-w-96 max-h-[600px]" role="status" aria-busy="true" aria-label="Loading notifications">
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -269,7 +269,7 @@ export function NotificationSkeleton() {
 
 export function CollaborationSkeleton() {
   return (
-    <div className="absolute top-4 right-4">
+    <div className="absolute top-4 right-4" role="status" aria-busy="true" aria-label="Loading collaboration panel">
       <Card className="w-80">
         <CardHeader className="pb-3">
           <div className="flex items-center justify-between">
@@ -313,7 +313,9 @@ export function CollaborationSkeleton() {
  */
 export function ProjectCardSkeleton() {
   return (
-    <SkeletonCard animation="shimmer" showHeader showFooter contentLines={2} />
+    <div role="status" aria-busy="true" aria-label="Loading project">
+      <SkeletonCard animation="shimmer" showHeader showFooter contentLines={2} />
+    </div>
   );
 }
 
@@ -322,7 +324,7 @@ export function ProjectCardSkeleton() {
  */
 export function ActivityFeedSkeleton({ count = 5 }: { count?: number }) {
   return (
-    <div className="space-y-3">
+    <div className="space-y-3" role="status" aria-busy="true" aria-label="Loading activity feed">
       {Array.from({ length: count }).map((_, i) => (
         <div key={i} className="flex items-start gap-3 p-3">
           <Skeleton animation="shimmer" className="w-8 h-8 rounded-lg flex-shrink-0" />
@@ -339,6 +341,59 @@ export function ActivityFeedSkeleton({ count = 5 }: { count?: number }) {
           </div>
         </div>
       ))}
+    </div>
+  );
+}
+
+/**
+ * Project Detail Skeleton - For project detail page loading
+ */
+export function ProjectDetailSkeleton() {
+  return (
+    <div className="flex flex-col h-full" role="status" aria-busy="true" aria-label="Loading project details">
+      {/* Header Skeleton */}
+      <div className="bg-white dark:bg-neutral-900 border-b px-6 py-4">
+        <div className="flex items-start justify-between gap-4 mb-4">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-3 mb-2">
+              <Skeleton animation="shimmer" className="h-8 w-8 rounded" />
+              <Skeleton animation="shimmer" className="h-7 w-64" />
+            </div>
+            <div className="flex items-center gap-3 ml-12">
+              <Skeleton animation="shimmer" className="h-6 w-20 rounded-full" />
+              <Skeleton animation="shimmer" className="h-6 w-28 rounded-full" />
+              <Skeleton animation="shimmer" className="h-6 w-24" />
+              <Skeleton animation="shimmer" className="h-6 w-20" />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Skeleton animation="shimmer" className="h-9 w-20" />
+            <Skeleton animation="shimmer" className="h-9 w-24" />
+            <Skeleton animation="shimmer" className="h-9 w-9" />
+          </div>
+        </div>
+      </div>
+
+      {/* Tab Navigation Skeleton */}
+      <div className="border-b px-6 py-2">
+        <div className="flex gap-1">
+          {['Overview', 'Tasks', 'Documents', 'Files', 'Assets', 'Boards', 'Messages'].map((tab) => (
+            <Skeleton key={tab} animation="shimmer" className="h-10 w-24" />
+          ))}
+        </div>
+      </div>
+
+      {/* Content Area Skeleton */}
+      <div className="flex-1 p-6 space-y-4">
+        <Skeleton animation="shimmer" className="h-6 w-48" />
+        <Skeleton animation="shimmer" className="h-4 w-full" />
+        <Skeleton animation="shimmer" className="h-4 w-3/4" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-6">
+          {[1, 2, 3].map((i) => (
+            <SkeletonCard key={i} animation="shimmer" contentLines={3} showFooter />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
@@ -406,7 +461,7 @@ export function TableSkeleton({ rows = 5, columns = 4 }: { rows?: number; column
 }
 
 interface LoadingScreenProps {
-  type: 'dashboard' | 'workflow' | 'messaging' | 'notification' | 'collaboration';
+  type: 'dashboard' | 'workflow' | 'messaging' | 'notification' | 'collaboration' | 'projectDetail';
   className?: string;
 }
 
@@ -416,7 +471,8 @@ export function LoadingScreen({ type, className }: LoadingScreenProps) {
     workflow: WorkflowSkeleton,
     messaging: MessagingSkeleton,
     notification: NotificationSkeleton,
-    collaboration: CollaborationSkeleton
+    collaboration: CollaborationSkeleton,
+    projectDetail: ProjectDetailSkeleton,
   };
 
   const Component = components[type];

--- a/src/components/messaging/ChatSidebar.tsx
+++ b/src/components/messaging/ChatSidebar.tsx
@@ -11,8 +11,9 @@
  * Extracted from MessagesNew.tsx for Phase 4.2 Technical Debt Resolution
  */
 
-import { Search, UserPlus, Star, BellOff, MessageCircle, Loader2 } from 'lucide-react';
+import { Search, UserPlus, Star, BellOff, MessageCircle } from 'lucide-react';
 import { Button, Card } from '@/components/ui';
+import { Skeleton } from '@/components/ui/skeleton';
 import { ConversationItem } from './ConversationSidebar';
 import { EmptyState, emptyStateConfigs } from '@/components/common/EmptyState';
 import type { Conversation, ConversationFilter } from './types';
@@ -120,8 +121,19 @@ export function ChatSidebar({
       {/* Conversation List */}
       <div className="flex-1 overflow-y-auto">
         {isLoading && conversations.length === 0 ? (
-          <div className="flex items-center justify-center h-32">
-            <Loader2 className="w-6 h-6 text-primary-600 animate-spin" />
+          <div className="p-4 space-y-3" role="status" aria-busy="true" aria-label="Loading conversations">
+            {[1, 2, 3, 4, 5].map((i) => (
+              <div key={i} className="flex items-center gap-3 p-3 rounded-lg">
+                <Skeleton animation="shimmer" variant="avatar" size="md" />
+                <div className="flex-1 space-y-1.5">
+                  <div className="flex items-center justify-between">
+                    <Skeleton animation="shimmer" className="h-4 w-24" />
+                    <Skeleton animation="shimmer" className="h-3 w-10" />
+                  </div>
+                  <Skeleton animation="shimmer" className="h-3 w-full" />
+                </div>
+              </div>
+            ))}
           </div>
         ) : filteredConversations.length === 0 ? (
           searchTerm ? (
@@ -145,14 +157,39 @@ export function ChatSidebar({
             />
           )
         ) : (
-          filteredConversations.map((conversation) => (
-            <ConversationItem
-              key={conversation.id}
-              conversation={conversation}
-              isSelected={selectedConversation?.id === conversation.id}
-              onClick={() => onConversationClick(conversation)}
-            />
-          ))
+          (() => {
+            const unread = filteredConversations.filter(c => c.unreadCount > 0);
+            const read = filteredConversations.filter(c => c.unreadCount === 0);
+            return (
+              <>
+                {unread.map((conversation) => (
+                  <ConversationItem
+                    key={conversation.id}
+                    conversation={conversation}
+                    isSelected={selectedConversation?.id === conversation.id}
+                    onClick={() => onConversationClick(conversation)}
+                  />
+                ))}
+                {unread.length > 0 && read.length > 0 && (
+                  <div className="flex items-center gap-3 px-4 py-2" role="separator">
+                    <div className="flex-1 h-px bg-neutral-200 dark:bg-neutral-700" />
+                    <span className="text-[10px] font-medium uppercase tracking-wider text-neutral-400 dark:text-neutral-500">
+                      Earlier
+                    </span>
+                    <div className="flex-1 h-px bg-neutral-200 dark:bg-neutral-700" />
+                  </div>
+                )}
+                {read.map((conversation) => (
+                  <ConversationItem
+                    key={conversation.id}
+                    conversation={conversation}
+                    isSelected={selectedConversation?.id === conversation.id}
+                    onClick={() => onConversationClick(conversation)}
+                  />
+                ))}
+              </>
+            );
+          })()
         )}
       </div>
     </Card>

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -488,6 +488,12 @@ export default function Notifications() {
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
           <div>
+            <Link
+              to="/projects"
+              className="inline-block text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 mb-2"
+            >
+              &larr; Back to Projects
+            </Link>
             <h1 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100" id="notifications-page-heading">
               Notifications
               {hasProjectContext && currentProject && (

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -53,7 +53,7 @@ export function Profile() {
               ← Back to Projects
             </Link>
             <h1 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100">Profile</h1>
-            <p className="text-neutral-600 mt-1">
+            <p className="text-neutral-600 dark:text-neutral-300 mt-1">
               Manage your account information and preferences
             </p>
           </div>
@@ -73,10 +73,10 @@ export function Profile() {
                   <User className="w-5 h-5 text-primary-600" />
                 </div>
                 <div>
-                  <h2 className="text-lg font-semibold text-neutral-900">
+                  <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
                     Personal Information
                   </h2>
-                  <p className="text-sm text-neutral-600">
+                  <p className="text-sm text-neutral-600 dark:text-neutral-400">
                     Your account details
                   </p>
                 </div>
@@ -84,47 +84,49 @@ export function Profile() {
 
               <div className="space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-neutral-700 mb-2">
+                  <label htmlFor="profile-name" className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
                     Full Name
                   </label>
                   <input
+                    id="profile-name"
                     type="text"
                     value={user?.name || ''}
-                    className="w-full px-4 py-3 text-sm border border-neutral-200 rounded-lg bg-neutral-50 text-neutral-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    className="w-full px-4 py-3 text-sm border border-neutral-200 dark:border-neutral-700 rounded-lg bg-neutral-50 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
                     readOnly
                   />
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-neutral-700 mb-2">
+                  <label htmlFor="profile-email" className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
                     Email Address
                   </label>
                   <div className="flex items-center gap-2">
-                    <Mail className="w-4 h-4 text-neutral-400" />
+                    <Mail className="w-4 h-4 text-neutral-400" aria-hidden="true" />
                     <input
+                      id="profile-email"
                       type="email"
                       value={user?.email || ''}
-                      className="flex-1 px-4 py-3 text-sm border border-neutral-200 rounded-lg bg-neutral-50 text-neutral-900 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                      className="flex-1 px-4 py-3 text-sm border border-neutral-200 dark:border-neutral-700 rounded-lg bg-neutral-50 dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
                       readOnly
                     />
                   </div>
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-neutral-700 mb-2">
+                  <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
                     User Type
                   </label>
-                  <div className="px-4 py-3 rounded-lg bg-neutral-50 border border-neutral-200 text-neutral-900 capitalize">
+                  <div className="px-4 py-3 rounded-lg bg-neutral-50 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 text-neutral-900 dark:text-neutral-100 capitalize">
                     {user?.userType || 'Not specified'}
                   </div>
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-neutral-700 mb-2">
+                  <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
                     Member Since
                   </label>
-                  <div className="flex items-center gap-2 px-4 py-3 rounded-lg bg-neutral-50 border border-neutral-200 text-neutral-900">
-                    <Calendar className="w-4 h-4 text-neutral-400" />
+                  <div className="flex items-center gap-2 px-4 py-3 rounded-lg bg-neutral-50 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 text-neutral-900 dark:text-neutral-100">
+                    <Calendar className="w-4 h-4 text-neutral-400" aria-hidden="true" />
                     {formatDate(user?.createdAt)}
                   </div>
                 </div>
@@ -138,23 +140,23 @@ export function Profile() {
                   <Shield className="w-5 h-5 text-success-600" />
                 </div>
                 <div>
-                  <h2 className="text-lg font-semibold text-neutral-900">
+                  <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
                     Security Settings
                   </h2>
-                  <p className="text-sm text-neutral-600">
+                  <p className="text-sm text-neutral-600 dark:text-neutral-400">
                     Manage your account security
                   </p>
                 </div>
               </div>
 
               <div className="space-y-3">
-                <button className="w-full flex items-center justify-between p-4 bg-neutral-50 rounded-lg border border-neutral-200 hover:bg-neutral-100 transition-colors">
+                <button className="w-full flex items-center justify-between p-4 bg-neutral-50 dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors">
                   <div className="text-left">
-                    <div className="flex items-center gap-2 font-medium text-neutral-900 mb-1">
-                      <Lock className="w-4 h-4" />
+                    <div className="flex items-center gap-2 font-medium text-neutral-900 dark:text-neutral-100 mb-1">
+                      <Lock className="w-4 h-4" aria-hidden="true" />
                       <span>Change Password</span>
                     </div>
-                    <p className="text-sm text-neutral-600">
+                    <p className="text-sm text-neutral-600 dark:text-neutral-400">
                       Update your account password
                     </p>
                   </div>
@@ -163,13 +165,13 @@ export function Profile() {
                   </Button>
                 </button>
 
-                <button className="w-full flex items-center justify-between p-4 bg-neutral-50 rounded-lg border border-neutral-200 hover:bg-neutral-100 transition-colors">
+                <button className="w-full flex items-center justify-between p-4 bg-neutral-50 dark:bg-neutral-800 rounded-lg border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors">
                   <div className="text-left">
-                    <div className="flex items-center gap-2 font-medium text-neutral-900 mb-1">
-                      <Shield className="w-4 h-4" />
+                    <div className="flex items-center gap-2 font-medium text-neutral-900 dark:text-neutral-100 mb-1">
+                      <Shield className="w-4 h-4" aria-hidden="true" />
                       <span>Two-Factor Authentication</span>
                     </div>
-                    <p className="text-sm text-neutral-600">
+                    <p className="text-sm text-neutral-600 dark:text-neutral-400">
                       Add an extra layer of security
                     </p>
                   </div>
@@ -187,13 +189,13 @@ export function Profile() {
             <Card className="p-6">
               <div className="flex items-center gap-2 mb-6">
                 <BarChart3 className="w-5 h-5 text-primary-600" />
-                <h3 className="text-lg font-semibold text-neutral-900">
+                <h3 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
                   Account Stats
                 </h3>
               </div>
 
               <div className="space-y-4">
-                <div className="flex justify-between items-center py-3 border-b border-neutral-100">
+                <div className="flex justify-between items-center py-3 border-b border-neutral-100 dark:border-neutral-800">
                   <div className="flex items-center gap-2 text-neutral-600">
                     <FileText className="w-4 h-4" />
                     <span className="text-sm">Projects Created</span>
@@ -205,7 +207,7 @@ export function Profile() {
                   )}
                 </div>
 
-                <div className="flex justify-between items-center py-3 border-b border-neutral-100">
+                <div className="flex justify-between items-center py-3 border-b border-neutral-100 dark:border-neutral-800">
                   <div className="flex items-center gap-2 text-neutral-600">
                     <FileText className="w-4 h-4" />
                     <span className="text-sm">Files Uploaded</span>
@@ -225,7 +227,7 @@ export function Profile() {
 
             {/* Quick Actions */}
             <Card className="p-6">
-              <h3 className="text-lg font-semibold text-neutral-900 mb-4">
+              <h3 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100 mb-4">
                 Quick Actions
               </h3>
 

--- a/src/pages/ProjectDetail/index.tsx
+++ b/src/pages/ProjectDetail/index.tsx
@@ -46,6 +46,7 @@ import { TiptapCollaborativeEditor } from '@/components/documents/TiptapCollabor
 import { FormationsTab } from '@/components/projects/FormationsTab';
 import { useFormations } from '@/hooks/useFormations';
 
+import { ProjectDetailSkeleton } from '@/components/loading/LoadingStates';
 import { PresenceIndicators, statusVariants, priorityVariants } from './ProjectDetailHelpers';
 import { TasksTabPanel, AssetsTabPanel, BoardsTabPanel } from './ProjectDetailTabs';
 import type { DesignBoard, ViewMode } from './ProjectDetailTabs';
@@ -199,12 +200,7 @@ export const ProjectDetail = () => {
   if (projectsLoading) {
     return (
       <DashboardLayout user={user || undefined} breadcrumbs={[{ label: 'Projects', path: '/projects' }, { label: 'Loading...', path: '#' }]}>
-        <div className="flex items-center justify-center h-full" role="status" aria-live="polite">
-          <div className="text-center">
-            <div className="w-12 h-12 border-4 border-primary-500 border-t-transparent rounded-full animate-spin mx-auto mb-4" aria-hidden="true" />
-            <p className="text-neutral-600">Loading project details...</p>
-          </div>
-        </div>
+        <ProjectDetailSkeleton />
       </DashboardLayout>
     );
   }
@@ -234,7 +230,7 @@ export const ProjectDetail = () => {
     >
       <div className="flex flex-col h-full">
         {/* Project Header */}
-        <header className="bg-white border-b px-6 py-4">
+        <header className="bg-white dark:bg-neutral-900 border-b border-neutral-200 dark:border-neutral-700 px-6 py-4">
           <div className="flex items-start justify-between gap-4 mb-4">
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-3 mb-2">
@@ -283,7 +279,7 @@ export const ProjectDetail = () => {
         </header>
 
         {/* Tab Navigation */}
-        <nav className="sticky top-0 z-10 bg-white border-b" aria-label="Project sections">
+        <nav className="sticky top-0 z-10 bg-white dark:bg-neutral-900 border-b border-neutral-200 dark:border-neutral-700" aria-label="Project sections">
           <Tabs value={activeTab} onValueChange={setActiveTab} className="px-6">
             <TabsList ref={tabListRef} className="w-full justify-start h-12 bg-transparent p-0 gap-1" role="tablist" aria-label="Project navigation tabs">
               <TabsTrigger value="overview" className={cn('data-[state=active]:border-b-2 data-[state=active]:border-primary-600', 'rounded-none border-b-2 border-transparent h-full px-4')} role="tab" aria-selected={activeTab === 'overview'} aria-controls="overview-panel" id="overview-tab">


### PR DESCRIPTION
## Summary
- Replace generic spinners with shimmer skeleton components across Messages, ProjectDetail, and ChatSidebar
- Add `aria-busy`, `role="status"`, and `aria-label` to all skeleton containers for screen reader support
- Add "Back to Projects" breadcrumb to Notifications page for navigation consistency
- Clean up DashboardShell: remove simulated loading timeout, 6 unused hooks, and placeholder views
- Polish EnhancedHeader: aria-labels on icon-only buttons, mobile search visibility, `aria-expanded` on mobile toggle
- Replace all hardcoded `gray-*` Tailwind classes with `neutral-*` design tokens across EnhancedHeader, DashboardShell, and LoadingStates
- Add dark mode support to Profile page (forms, headings, security section, stat borders) and ProjectDetail header/nav
- Add unread/read conversation separator in ChatSidebar

## Test plan
- [ ] `npm run typecheck` passes (only pre-existing errors in TeamDashboard.test.tsx)
- [ ] `npm run lint` passes on all 7 modified files (0 errors)
- [ ] Visual check: `/projects/:id` shows skeleton on load, 404 for invalid ID
- [ ] Visual check: `/messages` shows conversation list skeleton during load
- [ ] Visual check: `/notifications` has "Back to Projects" breadcrumb
- [ ] Visual check: `/profile` and `/settings` breadcrumbs are consistent
- [ ] Dark mode toggle: verify all modified pages render correctly in both themes
- [ ] Keyboard nav: tab through EnhancedHeader buttons, verify focus visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)