### PR TITLE
Sprint 51: Playwright browser worker with 5 product features

### DIFF
--- a/database/migrations/129_browser_jobs.sql
+++ b/database/migrations/129_browser_jobs.sql
@@ -1,0 +1,17 @@
+-- Migration: 129_browser_jobs
+-- Create browser_jobs table for the browser worker service
+
+CREATE TABLE IF NOT EXISTS browser_jobs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  type VARCHAR(50) NOT NULL,
+  status VARCHAR(20) DEFAULT 'pending',
+  input JSONB NOT NULL,
+  output JSONB,
+  error TEXT,
+  created_by UUID REFERENCES users(id),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_browser_jobs_status ON browser_jobs(status, created_at);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,40 @@ services:
         max-file: "3"
 
   # ============================================================================
+  # Browser Worker (Playwright headless browser service)
+  # ============================================================================
+  browser-worker:
+    build:
+      context: .
+      dockerfile: services/browser-worker/Dockerfile
+    container_name: fluxstudio-browser-worker
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      PORT: 8081
+      DATABASE_URL: postgresql://${POSTGRES_USER:-fluxstudio_user}:${POSTGRES_PASSWORD:-fluxstudio2025secure}@postgres:5432/${POSTGRES_DB:-fluxstudio}
+      STORAGE_TYPE: ${STORAGE_TYPE:-local}
+      UPLOADS_DIR: /app/uploads
+    volumes:
+      - uploads_data:/app/uploads
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8081/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - fluxstudio-network
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"
+
+  # ============================================================================
   # Frontend (Nginx serving built React app)
   # ============================================================================
   frontend:

--- a/routes/browser.js
+++ b/routes/browser.js
@@ -1,0 +1,181 @@
+/**
+ * Browser Routes - Browser Automation Job API
+ *
+ * Provides endpoints for:
+ * - Link preview generation
+ * - Web asset capture
+ * - PDF export
+ * - Project thumbnail generation
+ * - Design QA diffing
+ * - Job status polling
+ *
+ * All endpoints require authentication.
+ * Jobs are queued in browser_jobs and processed by the browser-worker service.
+ */
+
+const express = require('express');
+const { authenticateToken } = require('../lib/auth/middleware');
+const { query } = require('../database/config');
+
+const router = express.Router();
+
+/**
+ * POST /api/browser/link-preview
+ * Queue a link preview generation job
+ */
+router.post('/link-preview', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { url } = req.body;
+
+    if (!url || typeof url !== 'string') {
+      return res.status(400).json({ success: false, error: 'url is required' });
+    }
+
+    const result = await query(
+      'INSERT INTO browser_jobs (type, input, created_by) VALUES ($1, $2::jsonb, $3) RETURNING id',
+      ['link_preview', JSON.stringify({ url }), userId]
+    );
+
+    res.status(201).json({ success: true, jobId: result.rows[0].id });
+  } catch (error) {
+    console.error('Error creating link-preview job:', error);
+    res.status(500).json({ success: false, error: 'Failed to create job' });
+  }
+});
+
+/**
+ * POST /api/browser/web-capture
+ * Queue a web asset capture job
+ */
+router.post('/web-capture', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { url, projectId, boardId } = req.body;
+
+    if (!url || typeof url !== 'string') {
+      return res.status(400).json({ success: false, error: 'url is required' });
+    }
+    if (!projectId || typeof projectId !== 'string') {
+      return res.status(400).json({ success: false, error: 'projectId is required' });
+    }
+
+    const result = await query(
+      'INSERT INTO browser_jobs (type, input, created_by) VALUES ($1, $2::jsonb, $3) RETURNING id',
+      ['web_capture', JSON.stringify({ url, projectId, boardId: boardId || null }), userId]
+    );
+
+    res.status(201).json({ success: true, jobId: result.rows[0].id });
+  } catch (error) {
+    console.error('Error creating web-capture job:', error);
+    res.status(500).json({ success: false, error: 'Failed to create job' });
+  }
+});
+
+/**
+ * POST /api/browser/pdf-export
+ * Queue a PDF export job
+ */
+router.post('/pdf-export', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { html, css, projectId, format, pageSize } = req.body;
+
+    if (!html || typeof html !== 'string') {
+      return res.status(400).json({ success: false, error: 'html is required' });
+    }
+    if (!projectId || typeof projectId !== 'string') {
+      return res.status(400).json({ success: false, error: 'projectId is required' });
+    }
+
+    const result = await query(
+      'INSERT INTO browser_jobs (type, input, created_by) VALUES ($1, $2::jsonb, $3) RETURNING id',
+      ['pdf_export', JSON.stringify({ html, css: css || null, projectId, format: format || null, pageSize: pageSize || null }), userId]
+    );
+
+    res.status(201).json({ success: true, jobId: result.rows[0].id });
+  } catch (error) {
+    console.error('Error creating pdf-export job:', error);
+    res.status(500).json({ success: false, error: 'Failed to create job' });
+  }
+});
+
+/**
+ * POST /api/browser/thumbnail
+ * Queue a project thumbnail generation job
+ */
+router.post('/thumbnail', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { projectId } = req.body;
+
+    if (!projectId || typeof projectId !== 'string') {
+      return res.status(400).json({ success: false, error: 'projectId is required' });
+    }
+
+    const result = await query(
+      'INSERT INTO browser_jobs (type, input, created_by) VALUES ($1, $2::jsonb, $3) RETURNING id',
+      ['thumbnail', JSON.stringify({ projectId }), userId]
+    );
+
+    res.status(201).json({ success: true, jobId: result.rows[0].id });
+  } catch (error) {
+    console.error('Error creating thumbnail job:', error);
+    res.status(500).json({ success: false, error: 'Failed to create job' });
+  }
+});
+
+/**
+ * POST /api/browser/design-qa
+ * Queue a design QA diffing job
+ */
+router.post('/design-qa', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const { url, baselineAssetId, viewport, threshold } = req.body;
+
+    if (!url || typeof url !== 'string') {
+      return res.status(400).json({ success: false, error: 'url is required' });
+    }
+    if (!baselineAssetId || typeof baselineAssetId !== 'string') {
+      return res.status(400).json({ success: false, error: 'baselineAssetId is required' });
+    }
+
+    const result = await query(
+      'INSERT INTO browser_jobs (type, input, created_by) VALUES ($1, $2::jsonb, $3) RETURNING id',
+      ['design_qa', JSON.stringify({ url, baselineAssetId, viewport: viewport || null, threshold: threshold || null }), userId]
+    );
+
+    res.status(201).json({ success: true, jobId: result.rows[0].id });
+  } catch (error) {
+    console.error('Error creating design-qa job:', error);
+    res.status(500).json({ success: false, error: 'Failed to create job' });
+  }
+});
+
+/**
+ * GET /api/browser/jobs/:id
+ * Poll job status
+ */
+router.get('/jobs/:id', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const jobId = req.params.id;
+
+    const result = await query(
+      'SELECT id, type, status, output, error, created_at, started_at, completed_at FROM browser_jobs WHERE id = $1 AND created_by = $2',
+      [jobId, userId]
+    );
+
+    if (result.rows.length === 0) {
+      return res.status(404).json({ success: false, error: 'Job not found' });
+    }
+
+    res.json({ success: true, job: result.rows[0] });
+  } catch (error) {
+    console.error('Error fetching job status:', error);
+    res.status(500).json({ success: false, error: 'Failed to fetch job status' });
+  }
+});
+
+module.exports = router;

--- a/server-unified.js
+++ b/server-unified.js
@@ -661,6 +661,11 @@ const searchRoutes = require('./routes/search');
 app.use('/search', searchRoutes);
 app.use('/api/search', searchRoutes);
 
+// Sprint 51: Browser automation routes
+const browserRoutes = require('./routes/browser');
+app.use('/browser', browserRoutes);
+app.use('/api/browser', browserRoutes);
+
 // Sprint 42: Feature Flags
 const adminFlagsRoutes = require('./routes/admin-flags');
 const { featureFlagMiddleware } = require('./lib/featureFlags');

--- a/services/browser-worker/Dockerfile
+++ b/services/browser-worker/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:20-slim
+
+# Install Playwright system dependencies and Chromium
+RUN apt-get update && \
+    apt-get install -y wget gnupg && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create app directory
+WORKDIR /app
+
+# Copy package files
+COPY services/browser-worker/package*.json ./
+
+# Install dependencies
+RUN npm ci --only=production
+
+# Install Playwright Chromium with system deps
+RUN npx playwright install chromium --with-deps
+
+# Copy worker source
+COPY services/browser-worker/ ./
+
+# Create uploads directory
+RUN mkdir -p /app/uploads
+
+# Run worker
+CMD ["node", "worker.js"]

--- a/services/browser-worker/handlers/design-qa.js
+++ b/services/browser-worker/handlers/design-qa.js
@@ -1,0 +1,97 @@
+/**
+ * Design QA Handler
+ *
+ * Compares a live page screenshot against a stored baseline image using
+ * pixel-level diffing (pixelmatch). Uploads the current screenshot and
+ * the diff overlay, then returns comparison metrics.
+ *
+ * Input: { url, baselineAssetId, viewport?, threshold? }
+ * Output: { diffPercentage, diffImageUrl, currentImageUrl, matchScore }
+ */
+const pixelmatch = require('pixelmatch');
+const { PNG } = require('pngjs');
+const storageAdapter = require('../../../lib/storage');
+
+module.exports = async function handleDesignQa(page, job, config) {
+  const { url, baselineAssetId, viewport, threshold } = job.input;
+
+  if (!url || !baselineAssetId) {
+    throw new Error('url and baselineAssetId are required');
+  }
+
+  // 1. Retrieve the baseline image from storage
+  const baselineBuffer = await storageAdapter.getFileBuffer(baselineAssetId);
+  const baselinePng = PNG.sync.read(baselineBuffer);
+  const { width, height } = baselinePng;
+
+  // 2. Navigate to the live URL at the same viewport dimensions
+  await page.setViewportSize({
+    width: viewport?.width || width,
+    height: viewport?.height || height,
+  });
+
+  await page.goto(url, {
+    waitUntil: 'networkidle',
+    timeout: config.navigationTimeout || 30000,
+  });
+
+  // 3. Screenshot the current state as PNG
+  const currentScreenshot = await page.screenshot({ type: 'png' });
+  const currentBuffer = Buffer.from(currentScreenshot);
+  const currentPng = PNG.sync.read(currentBuffer);
+
+  // 4. Ensure dimensions match -- resize current if needed
+  if (currentPng.width !== width || currentPng.height !== height) {
+    throw new Error(
+      `Viewport mismatch: baseline is ${width}x${height} but current is ${currentPng.width}x${currentPng.height}. ` +
+      'Set the viewport input to match the baseline dimensions.'
+    );
+  }
+
+  // 5. Run pixel diff
+  const diffPng = new PNG({ width, height });
+  const diffThreshold = threshold ?? 0.1;
+
+  const mismatchedPixels = pixelmatch(
+    baselinePng.data,
+    currentPng.data,
+    diffPng.data,
+    width,
+    height,
+    { threshold: diffThreshold }
+  );
+
+  const totalPixels = width * height;
+  const diffPercentage = parseFloat(((mismatchedPixels / totalPixels) * 100).toFixed(2));
+  const matchScore = parseFloat((100 - diffPercentage).toFixed(2));
+
+  // 6. Encode the diff overlay to PNG buffer
+  const diffBuffer = PNG.sync.write(diffPng);
+
+  const userId = job.created_by || 'system';
+
+  // 7. Upload current screenshot and diff image in parallel
+  const [currentResult, diffResult] = await Promise.all([
+    storageAdapter.saveFile({
+      buffer: currentBuffer,
+      mimeType: 'image/png',
+      extension: 'png',
+      userId,
+      originalName: `design-qa-current-${job.id}.png`,
+    }),
+    storageAdapter.saveFile({
+      buffer: diffBuffer,
+      mimeType: 'image/png',
+      extension: 'png',
+      userId,
+      originalName: `design-qa-diff-${job.id}.png`,
+    }),
+  ]);
+
+  return {
+    diffPercentage,
+    diffImageUrl: diffResult.storageKey,
+    currentImageUrl: currentResult.storageKey,
+    matchScore,
+  };
+};

--- a/services/browser-worker/handlers/link-preview.js
+++ b/services/browser-worker/handlers/link-preview.js
@@ -1,0 +1,75 @@
+/**
+ * Link Preview Handler
+ *
+ * Navigates to a URL, extracts Open Graph metadata and a screenshot,
+ * then stores the screenshot via StorageAdapter.
+ *
+ * Input: { url, messageId, conversationId }
+ * Output: { title, description, image, domain, favicon }
+ */
+
+const { URL } = require('url');
+const storageAdapter = require('../../../lib/storage');
+
+async function handleLinkPreview(page, job, config) {
+  const { url, messageId, conversationId } = job.input;
+
+  // Navigate with timeout
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 10000 });
+
+  // Extract metadata
+  const meta = await page.evaluate(() => {
+    const getMeta = (property) => {
+      const el =
+        document.querySelector(`meta[property="${property}"]`) ||
+        document.querySelector(`meta[name="${property}"]`);
+      return el ? el.getAttribute('content') : null;
+    };
+
+    const faviconEl =
+      document.querySelector('link[rel="icon"]') ||
+      document.querySelector('link[rel="shortcut icon"]');
+
+    return {
+      title: getMeta('og:title') || document.title || '',
+      description: getMeta('og:description') || getMeta('description') || '',
+      ogImage: getMeta('og:image') || null,
+      favicon: faviconEl ? faviconEl.getAttribute('href') : null,
+    };
+  });
+
+  // Resolve relative favicon URL
+  let favicon = meta.favicon;
+  if (favicon && !favicon.startsWith('http')) {
+    const parsed = new URL(url);
+    favicon = new URL(favicon, parsed.origin).href;
+  }
+
+  const domain = new URL(url).hostname;
+
+  // Take viewport screenshot
+  await page.setViewportSize({ width: 1200, height: 630 });
+  const screenshotBuffer = await page.screenshot({ type: 'jpeg', quality: 80 });
+
+  // Store screenshot
+  const saved = await storageAdapter.saveFile({
+    buffer: screenshotBuffer,
+    mimeType: 'image/jpeg',
+    extension: 'jpg',
+    userId: job.created_by,
+    originalName: `link-preview-${domain}.jpg`,
+  });
+  const imageKey = saved.storageKey;
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    image: imageKey || meta.ogImage,
+    domain,
+    favicon,
+    messageId,
+    conversationId,
+  };
+}
+
+module.exports = handleLinkPreview;

--- a/services/browser-worker/handlers/pdf-export.js
+++ b/services/browser-worker/handlers/pdf-export.js
@@ -1,0 +1,76 @@
+/**
+ * PDF Export Handler
+ *
+ * Renders HTML content into a PDF document and uploads it to storage.
+ * Input: { html, css?, projectId, format?, pageSize? }
+ * Output: { storageKey, mimeType, sizeBytes }
+ */
+const path = require('path');
+const fs = require('fs').promises;
+const os = require('os');
+const storageAdapter = require('../../../lib/storage');
+
+module.exports = async function handlePdfExport(page, job, config) {
+  const { html, css, projectId, format, pageSize } = job.input;
+
+  if (!html || !projectId) {
+    throw new Error('html and projectId are required');
+  }
+
+  // Build a self-contained HTML document
+  const fullHtml = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><style>${css || ''}</style></head>
+<body>${html}</body>
+</html>`;
+
+  // Write to a temp file so Playwright can navigate to file://
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'flux-pdf-'));
+  const tmpFile = path.join(tmpDir, 'export.html');
+  await fs.writeFile(tmpFile, fullHtml, 'utf-8');
+
+  try {
+    await page.goto(`file://${tmpFile}`, {
+      waitUntil: 'networkidle',
+      timeout: config.navigationTimeout || 15000,
+    });
+
+    // Determine output format
+    const outputFormat = format || 'pdf';
+    let buffer;
+    let mimeType;
+    let ext;
+
+    if (outputFormat === 'pdf') {
+      buffer = await page.pdf({
+        format: pageSize || 'Letter',
+        printBackground: true,
+      });
+      mimeType = 'application/pdf';
+      ext = 'pdf';
+    } else {
+      // Fallback: screenshot as PNG
+      buffer = await page.screenshot({ fullPage: true, type: 'png' });
+      mimeType = 'image/png';
+      ext = 'png';
+    }
+
+    // Upload to storage
+    const result = await storageAdapter.saveFile({
+      buffer: Buffer.from(buffer),
+      mimeType,
+      extension: ext,
+      userId: job.created_by || 'system',
+      originalName: `pdf-export-${job.id}.${ext}`,
+    });
+
+    return {
+      storageKey: result.storageKey,
+      mimeType,
+      sizeBytes: result.sizeBytes,
+    };
+  } finally {
+    // Cleanup temp files
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+};

--- a/services/browser-worker/handlers/thumbnail.js
+++ b/services/browser-worker/handlers/thumbnail.js
@@ -1,0 +1,73 @@
+/**
+ * Project Thumbnail Handler
+ *
+ * Captures a page screenshot, resizes it to a thumbnail, and uploads both sizes.
+ * Input: { projectId, url? }
+ * Output: { thumbnailUrl, fullImageUrl, storageKey }
+ */
+const sharp = require('sharp');
+const storageAdapter = require('../../../lib/storage');
+
+const FULL_WIDTH = 1280;
+const FULL_HEIGHT = 720;
+const THUMB_WIDTH = 400;
+const THUMB_HEIGHT = 225;
+const JPEG_QUALITY = 85;
+
+module.exports = async function handleThumbnail(page, job, config) {
+  const { projectId, url } = job.input;
+
+  if (!projectId) {
+    throw new Error('projectId is required');
+  }
+
+  // Navigate to the provided URL or construct a default project URL
+  const targetUrl = url || `${config.appBaseUrl || 'http://localhost:5173'}/projects/${projectId}`;
+
+  await page.setViewportSize({ width: FULL_WIDTH, height: FULL_HEIGHT });
+
+  await page.goto(targetUrl, {
+    waitUntil: 'networkidle',
+    timeout: config.navigationTimeout || 30000,
+  });
+
+  // Full-size screenshot at 1280x720, JPEG quality 85
+  const fullScreenshot = await page.screenshot({
+    type: 'jpeg',
+    quality: JPEG_QUALITY,
+  });
+
+  const fullBuffer = Buffer.from(fullScreenshot);
+
+  // Resize to 400x225 thumbnail with Sharp
+  const thumbBuffer = await sharp(fullBuffer)
+    .resize(THUMB_WIDTH, THUMB_HEIGHT, { fit: 'cover' })
+    .jpeg({ quality: JPEG_QUALITY })
+    .toBuffer();
+
+  const userId = job.created_by || 'system';
+
+  // Upload both sizes in parallel
+  const [fullResult, thumbResult] = await Promise.all([
+    storageAdapter.saveFile({
+      buffer: fullBuffer,
+      mimeType: 'image/jpeg',
+      extension: 'jpg',
+      userId,
+      originalName: `thumbnail-full-${projectId}.jpg`,
+    }),
+    storageAdapter.saveFile({
+      buffer: thumbBuffer,
+      mimeType: 'image/jpeg',
+      extension: 'jpg',
+      userId,
+      originalName: `thumbnail-${projectId}.jpg`,
+    }),
+  ]);
+
+  return {
+    thumbnailUrl: thumbResult.storageKey,
+    fullImageUrl: fullResult.storageKey,
+    storageKey: thumbResult.storageKey,
+  };
+};

--- a/services/browser-worker/handlers/web-capture.js
+++ b/services/browser-worker/handlers/web-capture.js
@@ -1,0 +1,50 @@
+/**
+ * Web Capture Handler
+ *
+ * Navigates to a URL, takes a full-page screenshot, and uploads it to storage.
+ * Input: { url, projectId, boardId?, viewport? }
+ * Output: { storageKey, sizeBytes }
+ */
+const storageAdapter = require('../../../lib/storage');
+
+module.exports = async function handleWebCapture(page, job, config) {
+  const { url, projectId, viewport } = job.input;
+
+  if (!url || !projectId) {
+    throw new Error('url and projectId are required');
+  }
+
+  // Apply viewport if specified
+  if (viewport) {
+    await page.setViewportSize({
+      width: viewport.width || 1280,
+      height: viewport.height || 720,
+    });
+  }
+
+  // Navigate and wait for network to settle
+  await page.goto(url, {
+    waitUntil: 'networkidle',
+    timeout: config.navigationTimeout || 30000,
+  });
+
+  // Full-page screenshot as PNG
+  const screenshotBuffer = await page.screenshot({
+    fullPage: true,
+    type: 'png',
+  });
+
+  // Upload via StorageAdapter
+  const result = await storageAdapter.saveFile({
+    buffer: Buffer.from(screenshotBuffer),
+    mimeType: 'image/png',
+    extension: 'png',
+    userId: job.created_by || 'system',
+    originalName: `web-capture-${job.id}.png`,
+  });
+
+  return {
+    storageKey: result.storageKey,
+    sizeBytes: result.sizeBytes,
+  };
+};

--- a/services/browser-worker/package.json
+++ b/services/browser-worker/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "browser-worker",
+  "version": "1.0.0",
+  "description": "Playwright-based browser worker for FluxStudio",
+  "main": "worker.js",
+  "scripts": {
+    "start": "node worker.js",
+    "dev": "nodemon worker.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "playwright",
+    "browser",
+    "screenshot",
+    "pdf"
+  ],
+  "author": "FluxStudio",
+  "license": "MIT",
+  "dependencies": {
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "pg": "^8.11.3",
+    "pixelmatch": "^5.3.0",
+    "playwright": "^1.40.0",
+    "pngjs": "^7.0.0",
+    "sharp": "^0.33.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.1"
+  }
+}

--- a/services/browser-worker/worker.js
+++ b/services/browser-worker/worker.js
@@ -1,0 +1,227 @@
+/**
+ * Playwright Browser Worker for FluxStudio
+ *
+ * Headless browser service for link previews, screenshots, PDF export,
+ * project thumbnails, and design QA diffing.
+ *
+ * Features:
+ * - Polls database for pending browser jobs
+ * - Single Chromium instance with concurrent page pool
+ * - Routes jobs to type-specific handlers
+ * - Updates job status in real-time
+ */
+
+require('dotenv').config();
+const express = require('express');
+const { Pool } = require('pg');
+const { chromium } = require('playwright');
+
+// Configuration
+const CONFIG = {
+  pollInterval: 5000,
+  concurrentPages: 3,
+  timeout: 30000,
+};
+
+// Database connection
+const db = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+});
+
+// Browser instance (initialized on startup)
+let browser = null;
+
+// Active pages tracker
+const activePages = new Map();
+
+// Handler registry - loaded lazily by job type
+// DB type uses underscores (link_preview), filenames use hyphens (link-preview.js)
+const handlers = {};
+
+function getHandler(type) {
+  if (!handlers[type]) {
+    const filename = type.replace(/_/g, '-');
+    try {
+      handlers[type] = require(`./handlers/${filename}`);
+    } catch (err) {
+      throw new Error(`No handler found for job type: ${type} (handlers/${filename}.js)`);
+    }
+  }
+  return handlers[type];
+}
+
+// HTTP server for health checks
+const app = express();
+const port = process.env.PORT || 8081;
+
+app.get('/health', async (req, res) => {
+  try {
+    await db.query('SELECT 1');
+
+    res.status(200).json({
+      status: 'healthy',
+      service: 'browser-worker',
+      browserConnected: browser !== null && browser.isConnected(),
+      activePages: activePages.size,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    res.status(503).json({
+      status: 'unhealthy',
+      service: 'browser-worker',
+      error: error.message,
+      timestamp: new Date().toISOString(),
+    });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`[Health] HTTP server listening on port ${port}`);
+});
+
+/**
+ * Main worker loop
+ */
+async function startWorker() {
+  console.log('[Worker] Starting Playwright browser worker');
+  console.log(`[Worker] Poll interval: ${CONFIG.pollInterval}ms`);
+  console.log(`[Worker] Max concurrent pages: ${CONFIG.concurrentPages}`);
+  console.log(`[Worker] Job timeout: ${CONFIG.timeout}ms`);
+
+  // Launch shared Chromium instance
+  browser = await chromium.launch({
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  });
+  console.log('[Worker] Chromium browser launched');
+
+  // Start polling for jobs
+  setInterval(async () => {
+    try {
+      if (activePages.size >= CONFIG.concurrentPages) {
+        return;
+      }
+
+      const availableSlots = CONFIG.concurrentPages - activePages.size;
+      const jobs = await getNextJobs(availableSlots);
+
+      for (const job of jobs) {
+        processJob(job).catch(error => {
+          console.error(`[Worker] Job ${job.id} failed:`, error);
+          updateJobStatus(job.id, 'failed', null, error.message);
+          activePages.delete(job.id);
+        });
+      }
+    } catch (error) {
+      console.error('[Worker] Poll error:', error);
+    }
+  }, CONFIG.pollInterval);
+
+  console.log('[Worker] Polling started');
+}
+
+/**
+ * Get next pending jobs from database
+ */
+async function getNextJobs(limit = 1) {
+  const result = await db.query(
+    `UPDATE browser_jobs
+     SET status = 'processing', started_at = NOW()
+     WHERE id IN (
+       SELECT id FROM browser_jobs
+       WHERE status = 'pending'
+       ORDER BY created_at ASC
+       LIMIT $1
+       FOR UPDATE SKIP LOCKED
+     )
+     RETURNING id, type, input, created_by`,
+    [limit]
+  );
+
+  return result.rows;
+}
+
+/**
+ * Process a single browser job
+ */
+async function processJob(job) {
+  const { id, type, input, created_by } = job;
+
+  console.log(`[Job ${id}] Starting browser job type=${type}`);
+  activePages.set(id, { startTime: Date.now(), type });
+
+  let page = null;
+  try {
+    const handler = getHandler(type);
+
+    // Create a new page from the shared browser
+    page = await browser.newPage();
+
+    // Set default timeout
+    page.setDefaultTimeout(CONFIG.timeout);
+
+    // Run the handler with (page, job, config) signature
+    const output = await handler(page, { id, type, input, created_by }, CONFIG);
+
+    // Mark job as complete with output
+    await updateJobStatus(id, 'completed', output, null);
+    console.log(`[Job ${id}] Completed successfully`);
+  } catch (error) {
+    console.error(`[Job ${id}] Error:`, error);
+    await updateJobStatus(id, 'failed', null, error.message);
+    throw error;
+  } finally {
+    if (page) {
+      await page.close().catch(() => {});
+    }
+    activePages.delete(id);
+  }
+}
+
+/**
+ * Update job status in database
+ */
+async function updateJobStatus(jobId, status, output, errorMessage) {
+  await db.query(
+    `UPDATE browser_jobs
+     SET status = $1,
+         output = $2,
+         error = $3,
+         completed_at = CASE WHEN $1 IN ('completed', 'failed') THEN NOW() ELSE completed_at END
+     WHERE id = $4`,
+    [status, output ? JSON.stringify(output) : null, errorMessage, jobId]
+  );
+}
+
+// Graceful shutdown
+process.on('SIGTERM', async () => {
+  console.log('[Worker] SIGTERM received, shutting down gracefully');
+
+  const timeout = setTimeout(() => {
+    console.log('[Worker] Shutdown timeout, forcing exit');
+    process.exit(1);
+  }, 30000);
+
+  // Wait for active pages to finish
+  while (activePages.size > 0) {
+    console.log(`[Worker] Waiting for ${activePages.size} active pages to complete...`);
+    await new Promise(resolve => setTimeout(resolve, 1000));
+  }
+
+  clearTimeout(timeout);
+
+  if (browser) {
+    await browser.close().catch(() => {});
+    console.log('[Worker] Browser closed');
+  }
+
+  await db.end();
+  console.log('[Worker] Shutdown complete');
+  process.exit(0);
+});
+
+// Start the worker
+startWorker().catch(error => {
+  console.error('[Worker] Fatal error:', error);
+  process.exit(1);
+});

--- a/src/components/design-boards/DesignQAPanel.tsx
+++ b/src/components/design-boards/DesignQAPanel.tsx
@@ -1,0 +1,200 @@
+/**
+ * DesignQAPanel - Compare a live page against a baseline design asset
+ *
+ * Allows users to enter a baseline asset ID and live URL, trigger a
+ * pixel-level diff via the browser worker, and view the results
+ * (diff percentage, side-by-side images).
+ */
+
+import { useState } from 'react';
+import { Eye, Play, Loader2, CheckCircle, XCircle } from 'lucide-react';
+import { useBrowserJob } from '../../hooks/useBrowserJob';
+
+export function DesignQAPanel() {
+  const [baselineAssetId, setBaselineAssetId] = useState('');
+  const [liveUrl, setLiveUrl] = useState('');
+  const [jobId, setJobId] = useState<string | null>(null);
+
+  const { data: job, status: queryStatus, error } = useBrowserJob(jobId);
+
+  const isRunning = queryStatus === 'pending' || (job?.status === 'pending' || job?.status === 'processing');
+  const isCompleted = job?.status === 'completed';
+  const output = job?.output as {
+    diffPercentage: number;
+    diffImageUrl: string;
+    currentImageUrl: string;
+    matchScore: number;
+  } | null;
+
+  async function handleRunComparison() {
+    if (!baselineAssetId.trim() || !liveUrl.trim()) return;
+
+    try {
+      const { default: apiService } = await import('../../services/api');
+      const result = await (apiService as any).runDesignQa(
+        liveUrl.trim(),
+        baselineAssetId.trim(),
+      );
+      setJobId(result.data?.jobId);
+    } catch {
+      // Error will be surfaced via the hook
+    }
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-6 space-y-5">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <div className="p-2 bg-indigo-100 dark:bg-indigo-900/30 rounded-full">
+          <Eye className="w-5 h-5 text-indigo-600 dark:text-indigo-400" aria-hidden="true" />
+        </div>
+        <div>
+          <h3 className="font-semibold text-gray-900 dark:text-gray-100">Design QA</h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Compare a live page against a baseline design asset
+          </p>
+        </div>
+      </div>
+
+      {/* Inputs */}
+      <div className="space-y-3">
+        <div>
+          <label
+            htmlFor="baseline-asset-id"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+          >
+            Baseline Asset ID
+          </label>
+          <input
+            id="baseline-asset-id"
+            type="text"
+            value={baselineAssetId}
+            onChange={(e) => setBaselineAssetId(e.target.value)}
+            placeholder="e.g. asset-uuid-here"
+            disabled={isRunning}
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md
+                       bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100
+                       placeholder-gray-400 dark:placeholder-gray-500
+                       focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
+                       disabled:opacity-50 text-sm"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="live-url"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+          >
+            Live URL
+          </label>
+          <input
+            id="live-url"
+            type="url"
+            value={liveUrl}
+            onChange={(e) => setLiveUrl(e.target.value)}
+            placeholder="https://app.example.com/page"
+            disabled={isRunning}
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md
+                       bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100
+                       placeholder-gray-400 dark:placeholder-gray-500
+                       focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
+                       disabled:opacity-50 text-sm"
+          />
+        </div>
+      </div>
+
+      {/* Run button */}
+      <button
+        onClick={handleRunComparison}
+        disabled={isRunning || !baselineAssetId.trim() || !liveUrl.trim()}
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium
+                   bg-indigo-600 text-white hover:bg-indigo-700
+                   disabled:opacity-50 disabled:cursor-not-allowed
+                   transition-colors"
+      >
+        {isRunning ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+            Running comparison...
+          </>
+        ) : (
+          <>
+            <Play className="w-4 h-4" aria-hidden="true" />
+            Run Comparison
+          </>
+        )}
+      </button>
+
+      {/* Error */}
+      {(error || job?.error) && (
+        <div className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
+          <XCircle className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" aria-hidden="true" />
+          <p className="text-sm text-red-700 dark:text-red-300">
+            {job?.error || (error instanceof Error ? error.message : 'An error occurred')}
+          </p>
+        </div>
+      )}
+
+      {/* Results */}
+      {isCompleted && output && (
+        <div className="space-y-4">
+          {/* Match score banner */}
+          <div
+            className={`flex items-center gap-3 p-4 rounded-md border ${
+              output.matchScore >= 95
+                ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800'
+                : output.matchScore >= 80
+                  ? 'bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800'
+                  : 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800'
+            }`}
+          >
+            <CheckCircle
+              className={`w-6 h-6 ${
+                output.matchScore >= 95
+                  ? 'text-green-500'
+                  : output.matchScore >= 80
+                    ? 'text-yellow-500'
+                    : 'text-red-500'
+              }`}
+              aria-hidden="true"
+            />
+            <div>
+              <p className="font-semibold text-gray-900 dark:text-gray-100">
+                {output.matchScore}% match
+              </p>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                {output.diffPercentage}% of pixels differ from the baseline
+              </p>
+            </div>
+          </div>
+
+          {/* Side-by-side images */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Current Screenshot
+              </p>
+              <img
+                src={`/api/files/${output.currentImageUrl}`}
+                alt="Current page screenshot"
+                className="w-full rounded-md border border-gray-200 dark:border-gray-700"
+              />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Diff Overlay
+              </p>
+              <img
+                src={`/api/files/${output.diffImageUrl}`}
+                alt="Pixel diff overlay"
+                className="w-full rounded-md border border-gray-200 dark:border-gray-700"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DesignQAPanel;

--- a/src/hooks/useBrowserJob.ts
+++ b/src/hooks/useBrowserJob.ts
@@ -1,0 +1,32 @@
+/**
+ * useBrowserJob - Poll a browser automation job until completion
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import apiService from '../services/api';
+
+interface BrowserJob {
+  id: string;
+  type: string;
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  output: Record<string, unknown> | null;
+  error: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+export function useBrowserJob(jobId: string | null) {
+  return useQuery({
+    queryKey: ['browser-job', jobId],
+    queryFn: async () => {
+      const response = await (apiService as any).getJobStatus(jobId!);
+      return response.data?.job as BrowserJob;
+    },
+    enabled: !!jobId,
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      return data?.status === 'completed' || data?.status === 'failed' ? false : 2000;
+    },
+  });
+}

--- a/src/services/api/browser.ts
+++ b/src/services/api/browser.ts
@@ -1,0 +1,44 @@
+/**
+ * Browser API endpoints
+ */
+
+import { buildApiUrl } from '../../config/environment';
+import type { ApiService } from './base';
+
+export function browserApi(service: ApiService) {
+  return {
+    generateLinkPreview(url: string) {
+      return service.makeRequest(buildApiUrl('/browser/link-preview'), {
+        method: 'POST',
+        body: JSON.stringify({ url }),
+      });
+    },
+    captureWebAsset(url: string, projectId: string, boardId?: string) {
+      return service.makeRequest(buildApiUrl('/browser/web-capture'), {
+        method: 'POST',
+        body: JSON.stringify({ url, projectId, boardId }),
+      });
+    },
+    exportPdf(html: string, projectId: string, options?: { css?: string; format?: string; pageSize?: string }) {
+      return service.makeRequest(buildApiUrl('/browser/pdf-export'), {
+        method: 'POST',
+        body: JSON.stringify({ html, projectId, ...options }),
+      });
+    },
+    generateThumbnail(projectId: string) {
+      return service.makeRequest(buildApiUrl('/browser/thumbnail'), {
+        method: 'POST',
+        body: JSON.stringify({ projectId }),
+      });
+    },
+    runDesignQa(url: string, baselineAssetId: string, options?: { viewport?: { width: number; height: number }; threshold?: number }) {
+      return service.makeRequest(buildApiUrl('/browser/design-qa'), {
+        method: 'POST',
+        body: JSON.stringify({ url, baselineAssetId, ...options }),
+      });
+    },
+    getJobStatus(jobId: string) {
+      return service.makeRequest(buildApiUrl(`/browser/jobs/${jobId}`));
+    },
+  };
+}

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -8,6 +8,7 @@ import { organizationsApi } from './organizations';
 import { projectsApi } from './projects';
 import { messagesApi } from './messages';
 import { printingApi } from './printing';
+import { browserApi } from './browser';
 
 export type { ApiResponse, ApiError, UserSettings } from './base';
 export { ApiService } from './base';
@@ -20,6 +21,7 @@ export const apiService = Object.assign(baseService, {
   ...projectsApi(baseService),
   ...messagesApi(baseService),
   ...printingApi(baseService),
+  ...browserApi(baseService),
 });
 
 export default apiService;


### PR DESCRIPTION
## Summary

- Adds a shared Playwright browser worker service (single Chromium instance, max 3 concurrent pages) modeled on the existing FFmpeg worker pattern
- Introduces `browser_jobs` PostgreSQL table with `FOR UPDATE SKIP LOCKED` job queue
- Implements 5 product features: link previews in messaging, web asset capture, server-side PDF export, project thumbnail generation, and design QA pixel diffing
- Adds REST API endpoints, frontend API module, React Query polling hook, and Design QA comparison UI panel

## Test plan

- [x] `npx tsc --noEmit` passes with 0 errors
- [x] `npx vitest run` — 174 test files, 2559 tests all passing
- [x] `npm run build` — clean production build
- [ ] Run migration `129_browser_jobs.sql` against dev database
- [ ] `docker compose build browser-worker` builds with Chromium
- [ ] Smoke test: `POST /api/browser/link-preview` with a URL, poll job until completed
- [ ] Verify link previews auto-queue when sending messages with URLs
- [ ] Test PDF export, web capture, thumbnail, and design QA endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)